### PR TITLE
Change OTP parameter name

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -38,7 +38,7 @@ public class AuthenticatorConstants {
     public static final String OTP_NUMERIC_CHAR_SET = "9245378016";
     public static final String OTP_ALPHA_NUMERIC_CHAR_SET = "KIGXHOYSPRWCEFMVUQLZDNABJT9245378016";
     public static final String RESEND = "resendCode";
-    public static final String CODE = "OTPCode";
+    public static final String CODE = "OTPcode";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP = "otp";
     public static final String OTP_RESEND_ATTEMPTS = "otpResendAttempts";


### PR DESCRIPTION
## Purpose

The OTP code parameter name is changed with the fix https://github.com/wso2/identity-apps/pull/4370. Therefore this PR changes the OTP code param name from `OTPCode` to `OTPcode`.
