### PR TITLE
Add multiOptionURI parameter to the redirectURL 

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -180,7 +180,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                  * redirect the user to the Identifier First page to retrieve the username.
                  */
                 if (!isUserRedirectedFromIDF(request)) {
-                    redirectUserToIDF(response, context);
+                    redirectUserToIDF(request, response, context);
                     context.setProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR, true);
                     return;
                 }
@@ -981,12 +981,13 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     /**
      * This method is used to redirect the user to the username entering page (IDF: Identifier first).
      *
-     * @param context  The authentication context.
+     * @param request  Request.
      * @param response Response.
+     * @param context  The authentication context.
      * @throws AuthenticationFailedException If an error occurred while setting redirect url.
      */
-    private void redirectUserToIDF(HttpServletResponse response, AuthenticationContext context)
-            throws AuthenticationFailedException {
+    private void redirectUserToIDF(HttpServletRequest request, HttpServletResponse response,
+                                   AuthenticationContext context) throws AuthenticationFailedException {
 
         StringBuilder redirectUrl = new StringBuilder();
         String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
@@ -994,6 +995,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         redirectUrl.append("?");
 
         String queryParams = context.getContextIdIncludedQueryParams();
+        String multiOptionURI = AuthenticatorUtils.getMultiOptionURIQueryString(request);
         try {
             LOG.debug("Redirecting to identifier first flow since no authenticated user was found");
             if (queryParams != null) {
@@ -1004,6 +1006,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             redirectUrl.append(IDF_HANDLER_NAME);
             redirectUrl.append(":");
             redirectUrl.append(LOCAL_AUTHENTICATOR);
+            redirectUrl.append(multiOptionURI);
             response.sendRedirect(redirectUrl.toString());
         } catch (IOException e) {
             throw handleAuthErrorScenario(ERROR_CODE_ERROR_REDIRECTING_TO_IDF_PAGE);

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.auth.otp.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
@@ -986,6 +987,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
      * @param context  The authentication context.
      * @throws AuthenticationFailedException If an error occurred while setting redirect url.
      */
+    @SuppressFBWarnings("UNVALIDATED_REDIRECT")
     private void redirectUserToIDF(HttpServletRequest request, HttpServletResponse response,
                                    AuthenticationContext context) throws AuthenticationFailedException {
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.auth.otp.core.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.owasp.encoder.Encode;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,6 +36,7 @@ public class AuthenticatorUtils {
      * @param request HttpServletRequest.
      * @return Query parameter for the multi option URI.
      */
+    @SuppressFBWarnings("UNVALIDATED_REDIRECT")
     public static String getMultiOptionURIQueryString(HttpServletRequest request) {
 
         String multiOptionURI = "";


### PR DESCRIPTION
### Purpose
> $subject
> Adding this `multiOptionURI` parameter to the response enables `Choose a diiferent option` link in the sms-otp-authenticator flows which allows the user to go back to choose another authentication option as below.

<img width="505" alt="image" src="https://github.com/wso2-extensions/identity-auth-otp-commons/assets/75057725/aedf1f44-3898-4867-a679-1187785fda37">

<img width="473" alt="image" src="https://github.com/wso2-extensions/identity-auth-otp-commons/assets/75057725/f48881e7-c88d-45e9-9362-263d99a83d7e">

### Related Issue
- https://github.com/wso2/product-is/issues/17962
