### PR TITLE
Fix sms otp first factor is not working when multi attribute login is enabled

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -191,14 +191,14 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 // If the request is returned from the Identifier First page, resolve the user and set them in context.
                 context.removeProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR);
                 AuthenticatedUser authenticatedUser = resolveUserFromRequest(request, context);
-                authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUser);
+                authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUser, context);
                 setResolvedUserInContext(context, authenticatedUserFromContext);
             } else if (isPreviousIdPAuthenticationFlowHandler(context)) {
                 /*
                  * If the previous authentication has only been done by AuthenticationFlowHandlers, need to check if the
                  * user exists in the database.
                  */
-                authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext);
+                authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext, context);
                 setResolvedUserInContext(context, authenticatedUserFromContext);
             }
              // If the authenticated user is still null at this point, then an invalid user is trying to log in.
@@ -1083,10 +1083,11 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
      * @return Authenticated user retrieved from the user store.
      * @throws AuthenticationFailedException In occasions of failing.
      */
-    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUser)
+    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUser,
+                                                       AuthenticationContext context)
             throws AuthenticationFailedException {
 
-        User user = getUser(authenticatedUser);
+        User user = getUser(authenticatedUser, context);
         if (user == null) {
             return null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>5.25.285</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.106</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>


### PR DESCRIPTION
### Purpose
- Fix the issue, not receiving the otp when multi attribute login is enabled.

### Related issue
https://github.com/wso2/product-is/issues/20033

### When this PR should merged
- This PR should merged after https://github.com/wso2/carbon-identity-framework/pull/5588