### PR TITLE
Clear user input data and reset OTP retry count upon completion

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
@@ -140,6 +140,7 @@ public abstract class AbstractOTPExecutor implements Executor {
                     response.setResult(STATUS_COMPLETE);
                     Map<String, Object> contextProps = response.getContextProperties();
                     contextProps.put(OTP, null);
+                    flowExecutionContext.getUserInputData().remove(OTP);
                     handleClaimUpdate(flowExecutionContext, response);
                     publishPostOTPValidationEvent(flowExecutionContext, true, false);
                 }
@@ -191,6 +192,7 @@ public abstract class AbstractOTPExecutor implements Executor {
                 return;
             }
         } else if (STATUS_COMPLETE.equals(result)) {
+            flowExecutionContext.setProperty(OTP_RETRY_COUNT, null);
             response.getContextProperties().remove(OTP_RETRY_COUNT);
             return;
         }


### PR DESCRIPTION
## Purpose
When configuring multiple OTP executors in the self-registration flow, an error occurs after completing the first OTP step, preventing the second OTP from proceeding. This PR will fix it.

## Related issue
- https://github.com/wso2/product-is/issues/24691

## Implementation
This pull request introduces enhancements to the OTP execution flow in the `AbstractOTPExecutor` class to ensure better management of user input data and retry count during OTP validation and retry handling.

Updates to OTP validation and retry handling:

* [`AbstractOTPExecutor.java`](diffhunk://#diff-a6f27cbda95f640124185e95e9a68d20f348414deba303a72e59e596d57eddb5R143): Added a line to remove the `OTP` value from `userInputData` in the `processResponse` method to ensure cleanup after OTP validation.
* [`AbstractOTPExecutor.java`](diffhunk://#diff-a6f27cbda95f640124185e95e9a68d20f348414deba303a72e59e596d57eddb5R195): Added a line to reset the `OTP_RETRY_COUNT` property in the `handleRetry` method to ensure proper retry count management.