### PR TITLE
Add OTP data a map to the flow execution context

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/OTPExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/OTPExecutorConstants.java
@@ -61,4 +61,12 @@ public class OTPExecutorConstants {
 
         }
     }
+
+    public static class OTPData {
+
+        public static final String VALUE = "value";
+        public static final String GENERATED_TIME_IN_MILLIS = "generatedTimeInMillis";
+        public static final String VALIDITY_PERIOD_IN_MILLIS = "validityPeriodInMillis";
+        public static final String EXPIRY_TIME_IN_MILLIS = "expiryTimeInMillis";
+    }
 }


### PR DESCRIPTION
## Purpose

Add OTP data to flow execution context as a hash map to handle serialization/ deserialization.

## Issue

https://github.com/wso2/product-is/issues/24859