### PR TITLE
Extends authentication executor

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
@@ -33,7 +33,7 @@ import org.wso2.carbon.identity.event.handler.notification.NotificationConstants
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
-import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
+import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.utils.DiagnosticLog;
@@ -59,7 +59,7 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
  * Abstract class for OTP executors.
  * This class provides the common functionality for OTP executors.
  */
-public abstract class AbstractOTPExecutor implements Executor {
+public abstract class AbstractOTPExecutor extends AuthenticationExecutor {
 
     @Override
     public ExecutorResponse execute(FlowExecutionContext flowExecutionContext) throws FlowEngineException {

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutor.java
@@ -42,6 +42,13 @@ public class TestOTPExecutor extends AbstractOTPExecutor {
     private static final long DEFAULT_OTP_VALIDITY = 60000L;
     private static final int DEFAULT_MAX_RETRY = 3;
 
+
+    @Override
+    public String getAMRValue() {
+
+        return TestOTPExecutorConstants.TEST_AMR_VALUE;
+    }
+
     @Override
     protected Event getSendOTPEvent(OTPExecutorConstants.OTPScenarios otpScenario, OTP otp, FlowExecutionContext context)
             throws FlowEngineException {

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutorConstants.java
@@ -28,6 +28,7 @@ public class TestOTPExecutorConstants {
     }
 
     public static final String TEST_EXECUTOR_NAME = "TestExecutor";
+    public static final String TEST_AMR_VALUE = "TEST_AMR_VALUE";
     public static final String TEST_TEMPLATE_TYPE = "TEST_TEMPLATE_TYPE";
     public static final String TEST_CLAIM = "TEST_CLAIM";
     public static final String TEST_UPDATING_CLAIM = "TEST_UPDATING_CLAIM";

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.215</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request refactors the OTP executor hierarchy to improve code organization and updates the identity framework dependency. The main changes include switching the base class for `AbstractOTPExecutor` and adding support for AMR (Authentication Method Reference) values in the test implementation.

### Executor hierarchy refactor

* Changed `AbstractOTPExecutor` to extend `AuthenticationExecutor` instead of implementing the `Executor` interface, which aligns OTP executors with the authentication flow engine's design. (`AbstractOTPExecutor.java`) [[1]](diffhunk://#diff-a6f27cbda95f640124185e95e9a68d20f348414deba303a72e59e596d57eddb5L36-R36) [[2]](diffhunk://#diff-a6f27cbda95f640124185e95e9a68d20f348414deba303a72e59e596d57eddb5L62-R62)

### Test executor enhancements

* Added the `getAMRValue()` method to `TestOTPExecutor`, returning a constant AMR value for testing purposes. (`TestOTPExecutor.java`)
* Introduced the `TEST_AMR_VALUE` constant in `TestOTPExecutorConstants` to support the new AMR method. (`TestOTPExecutorConstants.java`)

### Dependency updates

* Updated the `carbon.identity.framework.version` property in `pom.xml` from `7.8.215` to `7.8.403` to use a newer version of the identity framework. (`pom.xml`)