### PR TITLE
refactor: update getCaptchaParams method signature to include HttpSer…

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -740,7 +740,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             queryParamsBuilder.append(RETRY_QUERY_PARAMS);
         }
         if (isOTPAsFirstFactor(context)) {
-            String captchaParams = getCaptchaParams(context, tenantDomain, authenticatedUser);
+            String captchaParams = getCaptchaParams(request, context, tenantDomain, authenticatedUser);
             queryParamsBuilder.append(captchaParams);
         }
         try {
@@ -1177,8 +1177,8 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
      * @param authenticatedUser Authenticated User.
      * @return String with the appended recaptcha params.
      */
-    private String getCaptchaParams(AuthenticationContext context, String tenantDomain,
-                                    AuthenticatedUser authenticatedUser) {
+    protected String getCaptchaParams(HttpServletRequest request, AuthenticationContext context, String tenantDomain,
+                                      AuthenticatedUser authenticatedUser) {
 
         if (!isOTPAsFirstFactor(context)) {
             return StringUtils.EMPTY;


### PR DESCRIPTION
### Proposed changes in this pull request

**Related Issues**

- https://github.com/wso2/product-is/issues/24183

This pull request updates the method signature for `getCaptchaParams` in `AbstractOTPAuthenticator` to include the `HttpServletRequest` parameter, and updates its usage accordingly. This change likely improves the flexibility or correctness of captcha parameter handling during OTP authentication.

Authentication/captcha parameter handling:

* Changed the signature of `getCaptchaParams` to accept an additional `HttpServletRequest` parameter, and updated its invocation in `redirectToOTPLoginPage` to pass the request object. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L1180-R1180) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L743-R743)