### PR TITLE
Handle locally credentials managed users

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/TestOTPExecutor.java
@@ -143,4 +143,9 @@ public class TestOTPExecutor extends AbstractOTPExecutor {
 
         return getName();
     }
+
+    protected boolean validateInitiation(FlowExecutionContext context) {
+
+        return true;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.499</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25636

This pull request introduces improvements to the OTP (One-Time Password) execution flow, focusing on enhancing initiation validation and ensuring OTPs are only sent for users with locally managed credentials. The changes also introduce a new abstract method for custom initiation validation logic.

Enhancements to OTP initiation and validation:

* Added a call to a new `validateInitiation` method before initiating OTP execution, ensuring that initiation only proceeds when validation passes. If validation fails, the response is set to require user input.
* Introduced an abstract `validateInitiation` method in `AbstractOTPExecutor`, allowing subclasses to define custom validation logic for OTP initiation.
* Provided a default implementation of `validateInitiation` in `TestOTPExecutor` for testing purposes, always returning `true`.

Security and delivery improvements:

* Updated `triggerOTP` to prevent sending OTPs to users whose credentials are not managed locally, adding an early return in such cases.