### PR TITLE
Use context-tenant-based username preprocessing in Abstract OTP Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -1121,7 +1121,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         if (StringUtils.isBlank(identifierFromRequest)) {
             throw handleAuthErrorScenario(ERROR_CODE_EMPTY_USERNAME);
         }
-        String username = FrameworkUtils.preprocessUsername(identifierFromRequest, context);
+        String username = FrameworkUtils.preprocessUsernameWithContextTenantDomain(identifierFromRequest, context);
         AuthenticatedUser user = new AuthenticatedUser();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userStoreDomain = UserCoreUtil.extractDomainFromName(username);


### PR DESCRIPTION
### Purpose
Update the Abstract OTP Authenticator to use the newly introduced username preprocessing method that relies on the context tenant domain. This ensures consistent username handling with the context-aware logic used across components.

### Goals
* Replace the existing use of `FrameworkUtils.preprocessUsername()` with the new context-based variant.
* Maintain consistent and reliable username preprocessing behavior.

### Approach
* Updated the call in `AbstractOTPAuthenticator` to use `FrameworkUtils.preprocessUsernameWithContextTenantDomain()`.
* No functional changes other than switching to the context-tenant-based preprocessing method.