### PR TITLE
Add retry-resend-control from Adaptive auth script.

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
         <artifactId>identity-auth-otp-commons</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
         <artifactId>identity-auth-otp-commons</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -126,8 +126,9 @@
                             !org.wso2.carbon.identity.auth.otp.core.internal,
                             org.wso2.carbon.identity.auth.otp.core.*; version = "${project.version}"
                         </Export-Package>
-                        <Import-Package>
+                            <Import-Package>
                             javax.servlet.http; version="${imp.pkg.version.javax.servlet}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.owasp.encoder; version="${encoder.wso2.import.version.range}",
                             org.wso2.carbon.extension.identity.helper.*; version="${identity.extension.utils.import.version.range}",

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.I
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
@@ -63,6 +64,7 @@ import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
@@ -72,6 +74,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -115,6 +119,7 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_OTP_EXPIRED;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_OTP_INVALID;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_RESEND_LIMIT_EXCEEDED;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_RETRYING_OTP_RESEND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_USER_ACCOUNT_LOCKED;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.FAILED_LOGIN_ATTEMPTS_CLAIM_URI;
@@ -123,14 +128,20 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.INVALID_USERNAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.IS_LOGIN_ATTEMPT_BY_INVALID_USER;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.LOCAL_AUTHENTICATOR;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_RESEND_LIMIT;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_ALLOWED_FAILURE_LIMIT;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_ALPHA_NUMERIC_CHAR_SET;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_NUMERIC_CHAR_SET;
-import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_RESEND_ATTEMPTS;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RECAPTCHA_PARAM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RESEND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RETRY_QUERY_PARAMS;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SCREEN_VALUE_QUERY_PARAM;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SKIP_RESEND_BLOCK_TIME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.UNKNOWN_USER;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.UNLOCK_QUERY_PARAM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.USERNAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.USERNAME_PARAM;
@@ -192,6 +203,109 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     /**
      * Check whether user based OTP resend blocking is enabled.
      *
+     * @param context Authentication context.
+     * @return true if enabled, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
+     */
+    protected boolean isUserBasedOTPResendBlockingEnabled(AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        Optional<Boolean> skipResendBlockTimeParam =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(getRuntimeParams(context),
+                        SKIP_RESEND_BLOCK_TIME);
+        if (skipResendBlockTimeParam.isPresent()) {
+            if (skipResendBlockTimeParam.get()) {
+                return false;
+            }
+        }
+        return isUserBasedOTPResendBlockingEnabled();
+    }
+
+    /**
+     * Check whether context based OTP resend blocking is enabled.
+     *
+     * @param context Authentication context.
+     * @return true if enabled, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
+     */
+    protected boolean isContextBasedOTPResendBlockingEnabled(AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        OptionalInt maximumAllowedResendAttemptsLimit =
+                AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(getRuntimeParams(context),
+                        MAXIMUM_RESEND_LIMIT);
+        if (maximumAllowedResendAttemptsLimit.isPresent()) {
+            int resendLimit = maximumAllowedResendAttemptsLimit.getAsInt();
+            if (resendLimit >= 0) {
+                return true;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Invalid value: %d for maximum allowed resend attempts limit. " +
+                                "The value should be a non-negative integer.",
+                        resendLimit));
+            }
+            AuthenticatorUtils.logDiagnostic(getName(),
+                    AuthenticatorConstants.LogConstants.ActionID.GET_MAX_RESEND_LIMIT,
+                    "Invalid value: " + resendLimit + " for maximum allowed resend attempts limit. " +
+                            "The value should be a non-negative integer.",
+                    DiagnosticLog.ResultStatus.FAILED,
+                    DiagnosticLog.LogDetailLevel.APPLICATION
+            );
+        }
+        return false;
+    }
+
+    /**
+     * Check whether context based retry blocking is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
+     */
+    protected boolean isContextBasedRetryBlockingEnabled(AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        OptionalInt maximumAllowedRetryAttemptsLimit =
+                AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(getRuntimeParams(context),
+                        MAXIMUM_ALLOWED_FAILURE_LIMIT);
+        if (maximumAllowedRetryAttemptsLimit.isPresent()) {
+            int retryLimit = maximumAllowedRetryAttemptsLimit.getAsInt();
+            if (retryLimit > 0) {
+                return true;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        String.format("Invalid value: %d for maximum allowed retry attempts limit. " +
+                                "The value should be a non-negative integer.", retryLimit));
+            }
+            AuthenticatorUtils.logDiagnostic(getName(),
+                    AuthenticatorConstants.LogConstants.ActionID.GET_MAX_FAILURE_LIMIT,
+                    "Invalid value: " + retryLimit + " for maximum allowed failure attempts limit. " +
+                            "The value should be a positive integer.",
+                    DiagnosticLog.ResultStatus.FAILED,
+                    DiagnosticLog.LogDetailLevel.APPLICATION
+            );
+        }
+        return false;
+    }
+
+    /**
+     * Check whether the authentication flow should be terminated when the OTP resend limit is exceeded.
+     *
+     * @return true if the flow should be terminated, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
+     */
+    protected boolean isTerminateOnResendLimitExceeded(AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        Optional<Boolean> terminateOnResendLimitExceededParam =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(getRuntimeParams(context),
+                        TERMINATE_ON_RESEND_LIMIT_EXCEEDED);
+        return terminateOnResendLimitExceededParam.isPresent() && terminateOnResendLimitExceededParam.get();
+    }
+
+    /**
+     * Check whether user based OTP resend blocking is enabled.
+     *
      * @return true if enabled, false otherwise.
      * @throws AuthenticationFailedException If an error occurs while checking the configuration.
      */
@@ -207,6 +321,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
 
         AuthenticatedUser authenticatedUserFromContext = getAuthenticatedUserFromContext(context);
         String applicationTenantDomain = context.getTenantDomain();
+        AuthenticatorConstants.AuthenticationScenarios scenario = resolveScenario(request, context);
 
         /*
          * If an invalid user has attempted to log in by submitting an OTP code, or if an invalid user has requested
@@ -217,6 +332,12 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         if (isLoginAttemptByInvalidUser(context, authenticatedUserFromContext)) {
             AuthenticatedUser invalidUser = new AuthenticatedUser();
             invalidUser.setUserName((String) context.getProperty(INVALID_USERNAME));
+            if (isOTPResendLimitExceededScenario(scenario, false , context)) {
+                handleOTPResendCountExceededScenario(request, response, context, invalidUser);
+                return;
+            } else if (scenario == RESEND_OTP) {
+                updateContextOTPResendCount(context);
+            }
             redirectToOTPLoginPage(invalidUser, applicationTenantDomain, false,
                     response, request, context);
             return;
@@ -247,6 +368,12 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
 
                         if (isOTPAsFirstFactor(context) &&
                                 Boolean.parseBoolean(IdentityUtil.getProperty(AuthenticatorConstants.HIDE_USER_EXISTENCE_CONFIG))) {
+                            if (isOTPResendLimitExceededScenario(scenario, false, context)) {
+                                handleOTPResendCountExceededScenario(request, response, context, null);
+                                return;
+                            } else if (scenario == RESEND_OTP) {
+                                updateContextOTPResendCount(context);
+                            }
                             redirectToOTPLoginPage(authenticatedUser, applicationTenantDomain, false, response, request, context);
                             return;
                         }
@@ -268,6 +395,12 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 invalidUser.setUserName(request.getParameter(USERNAME));
                 context.setProperty(IS_LOGIN_ATTEMPT_BY_INVALID_USER, true);
                 context.setProperty(INVALID_USERNAME, request.getParameter(USERNAME));
+                if (isOTPResendLimitExceededScenario(scenario, false, context)) {
+                    handleOTPResendCountExceededScenario(request, response, context, invalidUser);
+                    return;
+                } else if (scenario == RESEND_OTP) {
+                    updateContextOTPResendCount(context);
+                }
                 redirectToOTPLoginPage(invalidUser, applicationTenantDomain, false,
                         response, request, context);
                 return;
@@ -309,7 +442,6 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                     AuthenticatorUtils.maskIfRequired(authenticatedUserFromContext.getUserName()));
             throw new AuthenticationFailedException(ERROR_CODE_GETTING_ACCOUNT_STATE.getCode(), error, e);
         }
-        AuthenticatorConstants.AuthenticationScenarios scenario = resolveScenario(request, context);
         OTPResendClaims otpResendClaims = null;
         int otpResendCount = 0;
         boolean shouldUpdateUserClaim = false;
@@ -318,8 +450,9 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         authenticatedUserFromContext;
         boolean isUserExists = isUserExists(mappedLocalUser, context);
         if (scenario == INITIAL_OTP || scenario == RESEND_OTP) {
-            int allowedResendAttemptsCount = getMaximumResendAttempts(applicationTenantDomain);
-            if (isUserBasedOTPResendBlockingEnabled() && isUserExists) {
+            int allowedResendAttemptsCountForUserBeforeBlock = getMaximumResendAttempts(applicationTenantDomain);
+            boolean isUserBasedOTPResendBlockingEnabled = isUserBasedOTPResendBlockingEnabled(context) && isUserExists;
+            if (isUserBasedOTPResendBlockingEnabled) {
                 otpResendClaims = getOTPResendClaims();
 
                 // Get user-specific resend attempt count
@@ -337,7 +470,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         otpResendClaims.getLastResendTimeClaimUri(),
                         mappedLocalUser,
                         ERROR_CODE_ERROR_GETTING_LAST_RESEND_TIME);
-                if (otpResendCount >= allowedResendAttemptsCount) {
+                if (otpResendCount >= allowedResendAttemptsCountForUserBeforeBlock) {
                     // Convert block time (minutes) to milliseconds
                     int otpResendBlockTimeMinutes = getOTPResendBlockDuration(applicationTenantDomain);
                     if (StringUtils.isNotBlank(lastResendTimestamp)) {
@@ -347,7 +480,10 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         boolean withinBlockWindow = (now - lastResend) < blockTimeMillis;
 
                         if (withinBlockWindow) {
-                            handleOTPResendCountExceededScenario(request, response, context);
+                            // If the user is withing the block window, do not terminate the flow immediately.
+                            // Instead, redirect the user to the OTP login page with an error message indicating
+                            // that the resend limit has been exceeded.
+                            handleOTPResendCountExceededScenario(request, response, context, authenticatingUser, false);
                             return;
                         } else {
                             otpResendCount = 0;
@@ -359,15 +495,13 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                     otpResendCount++;
                     shouldUpdateUserClaim = true;
                 }
-            } else {
-                if (scenario == RESEND_OTP && context.getProperty(OTP_RESEND_ATTEMPTS) != null) {
-                    if (!StringUtils.isBlank(context.getProperty(OTP_RESEND_ATTEMPTS).toString())) {
-                        if ((int) context.getProperty(OTP_RESEND_ATTEMPTS) >= allowedResendAttemptsCount) {
-                            handleOTPResendCountExceededScenario(request, response, context);
-                            return;
-                        }
-                    }
-                }
+            }
+
+            if (isOTPResendLimitExceededScenario(scenario, isUserBasedOTPResendBlockingEnabled, context)) {
+                handleOTPResendCountExceededScenario(request, response, context, authenticatingUser);
+                return;
+            } else if (scenario == RESEND_OTP) {
+                updateContextOTPResendCount(context);
             }
             OTP otp = generateOTP(applicationTenantDomain);
             context.setProperty(OTP, otp);
@@ -411,17 +545,13 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 }
             }
 
-            if (isUserBasedOTPResendBlockingEnabled()) {
+            if (isUserBasedOTPResendBlockingEnabled) {
                 if (shouldUpdateUserClaim) {
                     Map<String, String> claimMap = new HashMap<>();
                     claimMap.put(otpResendClaims.getResendAttemptClaimUri(), String.valueOf((otpResendCount)));
                     claimMap.put(otpResendClaims.getLastResendTimeClaimUri(),
                             String.valueOf(System.currentTimeMillis()));
                     setUserClaimValueFromUserStore(claimMap, mappedLocalUser);
-                }
-            } else {
-                if (scenario == RESEND_OTP) {
-                    updateResendCount(context);
                 }
             }
 
@@ -436,10 +566,18 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
         AuthenticatedUser authenticatedUserFromContext = getAuthenticatedUserFromContext(context);
+        String applicationTenantDomain = context.getTenantDomain();
+        boolean isResendAttempt = Boolean.parseBoolean(request.getParameter(RESEND));
+
+        // If the scenario is a resend let the invalid login scenario handled from initiateAuthenticationRequest method.
         if (authenticatedUserFromContext == null) {
+            if (isResendAttempt) {
+                throw handleInvalidCredentialsScenario(ERROR_CODE_RETRYING_OTP_RESEND,
+                        AuthenticatorUtils.maskIfRequired((String) context.getProperty(INVALID_USERNAME)));
+            }
+            handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
             throw handleAuthErrorScenario(ERROR_CODE_NO_USER_FOUND);
         }
-        String applicationTenantDomain = context.getTenantDomain();
         /*
          * We need to identify the username that the server is using to identify the user. This is needed to handle
          * federated scenarios, since for federated users, the username in the authentication context is not same as the
@@ -466,12 +604,13 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         }
 
         /* If user requests a resend, throw error */
-        if (Boolean.parseBoolean(request.getParameter(RESEND))) {
+        if (isResendAttempt) {
             throw handleInvalidCredentialsScenario(ERROR_CODE_RETRYING_OTP_RESEND,
                     AuthenticatorUtils.maskIfRequired(authenticatedUserFromContext.getUserName()));
         }
         /* If an empty code is received, throw error. */
         if (StringUtils.isBlank(request.getParameter(CODE))) {
+            handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
             throw handleInvalidCredentialsScenario(ERROR_CODE_EMPTY_OTP_CODE,
                     AuthenticatorUtils.maskIfRequired(authenticatedUserFromContext.getUserName()));
         }
@@ -487,6 +626,8 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 // A mapped user is not available for isInitialFederationAttempt true scenario.
                 resetOtpFailedAttempts(authenticatingUser);
             }
+            resetContextRetryCount(context);
+            resetContextResendCount(context);
             publishPostOTPValidatedEvent(otpInContext, authenticatedUserFromContext, true, false, request, context);
             return;
         }
@@ -498,6 +639,9 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             // A mapped user is not available for isInitialFederationAttempt true scenario.
             handleOtpVerificationFail(authenticatingUser);
         }
+
+        handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
+
         if (otpInContext != null && otpInContext.isExpired()) {
             publishPostOTPValidatedEvent(otpInContext, authenticatedUserFromContext, false,
                     true, request, context);
@@ -508,6 +652,66 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                     false, request, context);
             throw handleAuthErrorScenario(ERROR_CODE_OTP_INVALID,
                     AuthenticatorUtils.maskIfRequired(authenticatedUserFromContext.getUserName()));
+        }
+    }
+
+    /**
+     * Check whether the current scenario is an OTP resend attempt and the resend limit has been
+     * exceeded for the context.
+     *
+     * @param scenario The current authentication scenario.
+     * @param isUserBasedOTPResendBlockingEnabled Whether user based OTP resend blocking is enabled.
+     * @param context Authentication context.
+     * @return true if it's an OTP resend attempt and the resend limit has been exceeded, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the resend limit.
+     */
+    private boolean isOTPResendLimitExceededScenario(AuthenticatorConstants.AuthenticationScenarios scenario,
+                                                  boolean isUserBasedOTPResendBlockingEnabled,
+                                                  AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        return scenario == RESEND_OTP
+                && (!isUserBasedOTPResendBlockingEnabled || isContextBasedOTPResendBlockingEnabled(context))
+                && isOTPResendLimitExceeded(context, context.getTenantDomain());
+
+
+    }
+
+    /**
+     *  Check whether the OTP resend count has exceeded the allowed limit for the context.
+     *
+     * @param context Authentication context.
+     * @param applicationTenantDomain Application tenant domain.
+     * @return true if the resend count has exceeded, false otherwise.
+     * @throws AuthenticationFailedException If an error occurs while checking the resend count.
+     */
+    private boolean isOTPResendLimitExceeded(AuthenticationContext context, String applicationTenantDomain)
+            throws AuthenticationFailedException {
+
+        int allowedResendAttemptsCount = getMaximumResendAttempts(applicationTenantDomain, context);
+        int currentResendAttempt = getCurrentResendAttempt(context);
+        return currentResendAttempt >= allowedResendAttemptsCount;
+    }
+
+    /**
+     * Handle the OTP login attempt count and block the authentication flow
+     * if the count has exceeded the allowed limit for the context.
+     *
+     * @param context Authentication context.
+     * @param applicationTenantDomain Application tenant domain.
+     * @throws AuthenticationFailedException If an error occurs while handling the retry blocking scenario.
+     */
+    private void handleInvalidOTPLoginAttempt(AuthenticationContext context, String applicationTenantDomain)
+            throws AuthenticationFailedException {
+
+        if (isContextBasedRetryBlockingEnabled(context)) {
+            // Update Context based retry counter only if context based retry blocking is enabled.
+            updateContextOTPRetryCount(context);
+            int maxRetryAttempts = getMaximumRetryAttempts(applicationTenantDomain, context);
+            int currentRetryAttempts = getCurrentRetryAttempt(context);
+            if (currentRetryAttempts >= maxRetryAttempts) {
+                handleOTPRetryCountExceededScenario(context);
+            }
         }
     }
 
@@ -821,8 +1025,14 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
 
         try {
             String multiOptionURIQueryString = AuthenticatorUtils.getMultiOptionURIQueryString(request);
+            String userName;
+            userName = context.getLastAuthenticatedUser() != null
+                    ? context.getLastAuthenticatedUser().getUserName()
+                    : StringUtils.isNotBlank((String) context.getProperty(INVALID_USERNAME))
+                    ? (String) context.getProperty(INVALID_USERNAME)
+                    : UNKNOWN_USER;
             String queryString = queryParams + AUTHENTICATORS_QUERY_PARAM + getName() +
-                    USERNAME_PARAM + context.getLastAuthenticatedUser().getUserName() + retryParam
+                    USERNAME_PARAM + userName + retryParam
                     + multiOptionURIQueryString;
             String errorPage = getErrorPageURL(context);
             String url = FrameworkUtils.appendQueryParamsStringToUrl(errorPage, queryString);
@@ -833,20 +1043,80 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     }
 
     /**
+     * Handle OTP resend attempts count exceeded scenarios by terminating the flow or redirecting to error page based on the configuration.
+     *
+     * @param request  HttpServletRequest.
+     * @param response HttpServletResponse.
+     * @param context  AuthenticationContext.
+     * @param user    Authenticated user.
+     * @throws AuthenticationFailedException If an error occurred.
+     */
+    private void handleOTPResendCountExceededScenario(HttpServletRequest request, HttpServletResponse response,
+                                                      AuthenticationContext context, AuthenticatedUser user)
+            throws AuthenticationFailedException {
+
+        handleOTPResendCountExceededScenario(request, response, context,
+                user, isTerminateOnResendLimitExceeded(context));
+    }
+
+    /**
+     * Handle OTP retry attempts count exceeded scenario by terminating the flow or redirecting to error page based on the configuration.
+     *
+     * @param context  AuthenticationContext.
+     * @throws AuthenticationFailedException If an error occurred.
+     */
+    private void handleOTPRetryCountExceededScenario(AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        context.setProperty(SKIP_RETRY_FROM_AUTHENTICATOR, true);
+        context.setProperty(FrameworkConstants.AUTH_ERROR_CODE,
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+    }
+
+    /**
      * Handle OTP resend attempts count exceeded scenarios.
      *
      * @param request  HttpServletRequest.
      * @param response HttpServletResponse.
      * @param context  AuthenticationContext.
+     * @param user    Authenticated user.
+     * @param terminateFlow Whether to terminate the flow by throwing an exception or to redirect to error page.
      * @throws AuthenticationFailedException If an error occurred.
      */
-    private void handleOTPResendCountExceededScenario(HttpServletRequest request,
-                                                      HttpServletResponse response, AuthenticationContext context)
+    private void handleOTPResendCountExceededScenario(HttpServletRequest request, HttpServletResponse response,
+                                                      AuthenticationContext context, AuthenticatedUser user,
+                                                      boolean terminateFlow)
             throws AuthenticationFailedException {
 
+        if (terminateFlow) {
+            context.setRetrying(false);
+            context.setProperty(FrameworkConstants.AUTH_ERROR_CODE,
+                    FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED);
+            if (user != null) {
+                throw handleAuthErrorScenario(ERROR_CODE_RESEND_LIMIT_EXCEEDED,
+                        AuthenticatorUtils.maskIfRequired(user.getUserName()));
+            }
+            throw handleAuthErrorScenario(ERROR_CODE_RESEND_LIMIT_EXCEEDED, UNKNOWN_USER);
+        }
         String queryParams = FrameworkUtils.getQueryStringWithFrameworkContextId(context.getQueryParams(),
                 context.getCallerSessionKey(), context.getContextIdentifier());
         redirectToErrorPage(request, response, context, queryParams, ERROR_USER_RESEND_COUNT_EXCEEDED_QUERY_PARAMS);
+    }
+
+    /**
+     * Handle OTP resend attempt within block period scenarios.
+     *
+     * @param request  HttpServletRequest.
+     * @param response HttpServletResponse.
+     * @param context  AuthenticationContext.
+     * @param user   Authenticated user.
+     * @throws AuthenticationFailedException If an error occurred.
+     */
+    private void handleOTPResendAttemptWithinBlockWindow(HttpServletRequest request, HttpServletResponse response,
+                                                         AuthenticationContext context, AuthenticatedUser user)
+            throws AuthenticationFailedException {
+
+        handleOTPResendCountExceededScenario(request, response, context, user, false);
     }
 
     protected AuthenticatorConstants.AuthenticationScenarios resolveScenario(HttpServletRequest request,
@@ -901,7 +1171,8 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             if (isShowAuthFailureReason()) {
                 String remainingNumberOfOtpAttemptsQueryParam = getRemainingNumberOfOtpAttemptsQueryParam();
                 if (StringUtils.isNotBlank(remainingNumberOfOtpAttemptsQueryParam)) {
-                    int remainingNumberOfOtpAttempts = getRemainingNumberOfOtpAttempts(authenticatedUser, tenantDomain);
+                    int remainingNumberOfOtpAttempts =
+                            getRemainingNumberOfOtpAttempts(authenticatedUser, tenantDomain, context);
                     queryParamsBuilder.append(getRemainingNumberOfOtpAttemptsQueryParam())
                             .append(remainingNumberOfOtpAttempts);
                 }
@@ -922,13 +1193,56 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     }
 
     /**
-     * Get remaining number of otp attempts.
+     * Get remaining number of OTP attempts to show in the login page when the user has entered an invalid OTP and
+     * retrying.This is calculated based on the remaining number of attempts for account lock and context based retry
+     * blocking if enabled.
      *
-     * @param authenticatedUser Authenticated User.
-     * @param tenantDomain Tenant Domain
-     * @throws AuthenticationFailedException Exception on authentication failure.
+     * @param authenticatedUser Authenticated user.
+     * @param tenantDomain Tenant domain.
+     * @param context Authentication context.
+     * @return Query parameter to show the remaining number of OTP attempts.
      */
-    private int getRemainingNumberOfOtpAttempts(AuthenticatedUser authenticatedUser, String tenantDomain)
+    private int getRemainingNumberOfOtpAttempts(AuthenticatedUser authenticatedUser,
+                                                String tenantDomain,
+                                                AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (isContextBasedRetryBlockingEnabled(context)) {
+            return Math.min(getRemainingNumberOfOtpAttemptsForAccountLock(authenticatedUser, tenantDomain),
+                    getRemainingNumberOfContextBasedRetryAttempts(tenantDomain, context));
+        } else {
+            return getRemainingNumberOfOtpAttemptsForAccountLock(authenticatedUser, tenantDomain);
+        }
+    }
+
+    /**
+     * Get the remaining number of context based retry attempts.
+     *
+     * @param tenantDomain Tenant domain.
+     * @param context Authentication context.
+     * @return Remaining number of context based retry attempts.
+     * @throws AuthenticationFailedException If an error occurred while getting the remaining number of
+     *                                       context based retry attempts.
+     */
+    private int getRemainingNumberOfContextBasedRetryAttempts(String tenantDomain, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        int maxRetryAttempts = getMaximumRetryAttempts(context.getTenantDomain(), context);
+        int currentRetryAttempts = getCurrentRetryAttempt(context);
+        int remainingRetryAttempts = maxRetryAttempts - currentRetryAttempts;
+        // If the remaining retry attempts is less than 0, then return 0.
+        return Math.max(remainingRetryAttempts, 0);
+    }
+
+    /**
+     * Get the remaining number of OTP attempts for account lock.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @param tenantDomain      Tenant domain.
+     * @return Remaining number of OTP attempts for account lock.
+     * @throws AuthenticationFailedException If an error occurred while getting the remaining number of OTP attempts.
+     */
+    private int getRemainingNumberOfOtpAttemptsForAccountLock(AuthenticatedUser authenticatedUser, String tenantDomain)
             throws AuthenticationFailedException {
 
         try {
@@ -1085,18 +1399,164 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     }
 
     /**
-     * Initialize or increment the number of times the OTP was resent to the user.
+     * Get the number of maximum attempts the user is allowed resend the OTP.
+     *
+     * @param tenantDomain  Tenant Domain.
+     * @param context Authentication Context.
+     * @return The maximum number of resend attempts.
+     * @throws AuthenticationFailedException If an error occurs when retrieving config.
+     */
+    protected int getMaximumResendAttempts(String tenantDomain, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (isContextBasedOTPResendBlockingEnabled(context)) {
+            OptionalInt maxResendAttemptsFromContext = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
+                    getRuntimeParams(context), MAXIMUM_RESEND_LIMIT);
+            return maxResendAttemptsFromContext.isPresent() ?
+                    maxResendAttemptsFromContext.getAsInt() : getMaximumResendAttempts(tenantDomain);
+        }
+
+        return getMaximumResendAttempts(tenantDomain);
+    }
+
+    /**
+     * Get the number of maximum attempts the user is allowed to retry OTP submission.
+     *
+     * @param tenantDomain  Tenant Domain.
+     * @param context Authentication Context.
+     * @return The maximum number of retry attempts.
+     * @throws AuthenticationFailedException If an error occurs when retrieving config.
+     */
+    protected int getMaximumRetryAttempts(String tenantDomain, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (isContextBasedRetryBlockingEnabled(context)) {
+            OptionalInt maxRetryAttemptsFromContext = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
+                    getRuntimeParams(context), MAXIMUM_ALLOWED_FAILURE_LIMIT);
+            return maxRetryAttemptsFromContext.isPresent() ? maxRetryAttemptsFromContext.getAsInt() :
+                    Integer.MAX_VALUE;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Initializes or increments the OTP resend attempt counter for the current authentication
+     * context. This counter is maintained only in context and is not persisted as a user attribute.
+     * The updated count is evaluated when enforcing context-level resend limits.
+     *
+     * @param context Authentication context of the ongoing authentication flow.
+     */
+    protected void updateContextOTPResendCount(AuthenticationContext context) {
+
+        incrementContextCounter(context, getResendAttemptsPropertyKey());
+    }
+
+    /**
+     * Initializes or increments the OTP submission attempt counter for the current authentication
+     * context. This counter is maintained only in context and is not persisted as a user attribute.
+     * The updated count is evaluated when enforcing context-level retry limits.
+     *
+     * @param context Authentication context of the ongoing authentication flow.
+     */
+    protected void updateContextOTPRetryCount(AuthenticationContext context) {
+
+        incrementContextCounter(context, getRetryAttemptsPropertyKey());
+    }
+
+    /**
+     * Initializes a context counter to 1 if not already set, or increments it by 1.
+     *
+     * @param context Authentication context of the ongoing authentication flow.
+     * @param key     The context property key of the counter.
+     */
+    private void incrementContextCounter(AuthenticationContext context, String key) {
+
+        if (context.getProperty(key) == null ||
+                StringUtils.isBlank(context.getProperty(key).toString())) {
+            context.setProperty(key, 1);
+        } else {
+            context.setProperty(key, (int) context.getProperty(key) + 1);
+        }
+    }
+
+    /**
+     * Reset the number of times the user attempted to submit OTP.
      *
      * @param context   Authentication Context.
      */
-    private void updateResendCount(AuthenticationContext context) {
+    protected void resetContextRetryCount(AuthenticationContext context) {
 
-        if (context.getProperty(OTP_RESEND_ATTEMPTS) == null ||
-                StringUtils.isBlank(context.getProperty(OTP_RESEND_ATTEMPTS).toString())) {
-            context.setProperty(OTP_RESEND_ATTEMPTS, 1);
-        } else {
-            context.setProperty(OTP_RESEND_ATTEMPTS, (int) context.getProperty(OTP_RESEND_ATTEMPTS) + 1);
+        context.setProperty(getRetryAttemptsPropertyKey(), 0);
+    }
+
+    /**
+     * Reset the number of times the OTP was resent to the user.
+     *
+     * @param context   Authentication Context.
+     */
+    protected void resetContextResendCount(AuthenticationContext context) {
+
+        context.setProperty(getResendAttemptsPropertyKey(), 0);
+    }
+
+    /**
+     * Get the current count of OTP retry attempts from the context.
+     *
+     * @param context   Authentication Context.
+     * @return The number of times the user attempted to submit OTP in the current authentication flow.
+     */
+    protected int getCurrentRetryAttempt(AuthenticationContext context) {
+
+        return getContextCounter(context, getRetryAttemptsPropertyKey());
+    }
+
+    /**
+     * Get the current count of OTP resend attempts from the context.
+     *
+     * @param context   Authentication Context.
+     * @return The number of times the user attempted to resend OTP in the current authentication flow.
+     */
+    protected int getCurrentResendAttempt(AuthenticationContext context) {
+
+        return getContextCounter(context, getResendAttemptsPropertyKey());
+    }
+
+    /**
+     * Get the current value of a context counter, returning 0 if not set.
+     *
+     * @param context Authentication context of the ongoing authentication flow.
+     * @param key     The context property key of the counter.
+     * @return The current counter value, or 0 if absent or blank.
+     */
+    private int getContextCounter(AuthenticationContext context, String key) {
+
+        if (context.getProperty(key) == null ||
+                StringUtils.isBlank(context.getProperty(key).toString())) {
+            return 0;
         }
+        return Integer.parseInt(context.getProperty(key).toString());
+    }
+
+    /**
+     * Get the context property key used to store the OTP resend attempt count.
+     * Subclasses may override this to use a different key.
+     *
+     * @return The context property key for OTP resend attempts.
+     */
+    protected String getResendAttemptsPropertyKey() {
+
+        return DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+    }
+
+    /**
+     * Get the context property key used to store the OTP retry attempt count.
+     * Subclasses may override this to use a different key.
+     *
+     * @return The context property key for OTP retry attempts.
+     */
+    protected String getRetryAttemptsPropertyKey() {
+
+        return DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -210,7 +210,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         OptionalInt maximumAllowedResendAttemptsLimit =
-                AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(getRuntimeParams(context),
+                AuthenticatorUtils.getIntRuntimeParamByName(getRuntimeParams(context),
                         MAXIMUM_RESEND_LIMIT);
         if (maximumAllowedResendAttemptsLimit.isPresent()) {
             int resendLimit = maximumAllowedResendAttemptsLimit.getAsInt();
@@ -222,7 +222,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                                 "The value should be a non-negative integer.",
                         resendLimit));
             }
-            AuthenticatorUtils.logDiagnostic(getName(),
+            AuthenticatorUtils.triggerDiagnosticLog(getName(),
                     AuthenticatorConstants.LogConstants.ActionID.GET_MAX_RESEND_LIMIT,
                     "Invalid value: " + resendLimit + " for maximum allowed resend attempts limit. " +
                             "The value should be a non-negative integer.",
@@ -243,7 +243,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         OptionalInt maximumAllowedRetryAttemptsLimit =
-                AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(getRuntimeParams(context),
+                AuthenticatorUtils.getIntRuntimeParamByName(getRuntimeParams(context),
                         MAXIMUM_ALLOWED_FAILURE_LIMIT);
         if (maximumAllowedRetryAttemptsLimit.isPresent()) {
             int retryLimit = maximumAllowedRetryAttemptsLimit.getAsInt();
@@ -255,7 +255,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         String.format("Invalid value: %d for maximum allowed retry attempts limit. " +
                                 "The value should be a positive integer.", retryLimit));
             }
-            AuthenticatorUtils.logDiagnostic(getName(),
+            AuthenticatorUtils.triggerDiagnosticLog(getName(),
                     AuthenticatorConstants.LogConstants.ActionID.GET_MAX_FAILURE_LIMIT,
                     "Invalid value: " + retryLimit + " for maximum allowed failure attempts limit. " +
                             "The value should be a positive integer.",
@@ -276,7 +276,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         Optional<Boolean> terminateOnResendLimitExceededParam =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(getRuntimeParams(context),
+                AuthenticatorUtils.getBooleanRuntimeParamByName(getRuntimeParams(context),
                         TERMINATE_ON_RESEND_LIMIT_EXCEEDED);
         return terminateOnResendLimitExceededParam.isPresent() && terminateOnResendLimitExceededParam.get();
     }
@@ -1371,7 +1371,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         if (isContextBasedOTPResendBlockingEnabled(context)) {
-            OptionalInt maxResendAttemptsFromContext = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
+            OptionalInt maxResendAttemptsFromContext = AuthenticatorUtils.getIntRuntimeParamByName(
                     getRuntimeParams(context), MAXIMUM_RESEND_LIMIT);
             return maxResendAttemptsFromContext.isPresent() ?
                     maxResendAttemptsFromContext.getAsInt() : getMaximumResendAttempts(tenantDomain);
@@ -1392,7 +1392,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         if (isContextBasedRetryBlockingEnabled(context)) {
-            OptionalInt maxRetryAttemptsFromContext = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
+            OptionalInt maxRetryAttemptsFromContext = AuthenticatorUtils.getIntRuntimeParamByName(
                     getRuntimeParams(context), MAXIMUM_ALLOWED_FAILURE_LIMIT);
             return maxRetryAttemptsFromContext.isPresent() ? maxRetryAttemptsFromContext.getAsInt() :
                     Integer.MAX_VALUE;

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -139,7 +139,6 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RESEND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RETRY_QUERY_PARAMS;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SCREEN_VALUE_QUERY_PARAM;
-import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SKIP_RESEND_BLOCK_TIME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.UNKNOWN_USER;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.UNLOCK_QUERY_PARAM;
@@ -198,27 +197,6 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     protected int getOTPResendBlockDuration(String tenantDomain) throws AuthenticationFailedException {
 
         throw new NotImplementedException("User based OTP resend blocking is not supported.");
-    }
-
-    /**
-     * Check whether user based OTP resend blocking is enabled.
-     *
-     * @param context Authentication context.
-     * @return true if enabled, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
-     */
-    protected boolean isUserBasedOTPResendBlockingEnabled(AuthenticationContext context)
-            throws AuthenticationFailedException {
-
-        Optional<Boolean> skipResendBlockTimeParam =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(getRuntimeParams(context),
-                        SKIP_RESEND_BLOCK_TIME);
-        if (skipResendBlockTimeParam.isPresent()) {
-            if (skipResendBlockTimeParam.get()) {
-                return false;
-            }
-        }
-        return isUserBasedOTPResendBlockingEnabled();
     }
 
     /**
@@ -451,7 +429,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         boolean isUserExists = isUserExists(mappedLocalUser, context);
         if (scenario == INITIAL_OTP || scenario == RESEND_OTP) {
             int allowedResendAttemptsCountForUserBeforeBlock = getMaximumResendAttempts(applicationTenantDomain);
-            boolean isUserBasedOTPResendBlockingEnabled = isUserBasedOTPResendBlockingEnabled(context) && isUserExists;
+            boolean isUserBasedOTPResendBlockingEnabled = isUserBasedOTPResendBlockingEnabled() && isUserExists;
             if (isUserBasedOTPResendBlockingEnabled) {
                 otpResendClaims = getOTPResendClaims();
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -275,7 +275,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             if (LOG.isDebugEnabled()) {
                 LOG.debug(
                         String.format("Invalid value: %d for maximum allowed retry attempts limit. " +
-                                "The value should be a non-negative integer.", retryLimit));
+                                "The value should be a positive integer.", retryLimit));
             }
             AuthenticatorUtils.logDiagnostic(getName(),
                     AuthenticatorConstants.LogConstants.ActionID.GET_MAX_FAILURE_LIMIT,
@@ -480,7 +480,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         boolean withinBlockWindow = (now - lastResend) < blockTimeMillis;
 
                         if (withinBlockWindow) {
-                            // If the user is withing the block window, do not terminate the flow immediately.
+                            // If the user is within the block window, do not terminate the flow immediately.
                             // Instead, redirect the user to the OTP login page with an error message indicating
                             // that the resend limit has been exceeded.
                             handleOTPResendCountExceededScenario(request, response, context, authenticatingUser, false);
@@ -1103,22 +1103,6 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         redirectToErrorPage(request, response, context, queryParams, ERROR_USER_RESEND_COUNT_EXCEEDED_QUERY_PARAMS);
     }
 
-    /**
-     * Handle OTP resend attempt within block period scenarios.
-     *
-     * @param request  HttpServletRequest.
-     * @param response HttpServletResponse.
-     * @param context  AuthenticationContext.
-     * @param user   Authenticated user.
-     * @throws AuthenticationFailedException If an error occurred.
-     */
-    private void handleOTPResendAttemptWithinBlockWindow(HttpServletRequest request, HttpServletResponse response,
-                                                         AuthenticationContext context, AuthenticatedUser user)
-            throws AuthenticationFailedException {
-
-        handleOTPResendCountExceededScenario(request, response, context, user, false);
-    }
-
     protected AuthenticatorConstants.AuthenticationScenarios resolveScenario(HttpServletRequest request,
                                                                              AuthenticationContext context) {
 
@@ -1209,7 +1193,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
 
         if (isContextBasedRetryBlockingEnabled(context)) {
             return Math.min(getRemainingNumberOfOtpAttemptsForAccountLock(authenticatedUser, tenantDomain),
-                    getRemainingNumberOfContextBasedRetryAttempts(tenantDomain, context));
+                    getRemainingNumberOfContextBasedRetryAttempts(context));
         } else {
             return getRemainingNumberOfOtpAttemptsForAccountLock(authenticatedUser, tenantDomain);
         }
@@ -1218,13 +1202,12 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     /**
      * Get the remaining number of context based retry attempts.
      *
-     * @param tenantDomain Tenant domain.
      * @param context Authentication context.
      * @return Remaining number of context based retry attempts.
      * @throws AuthenticationFailedException If an error occurred while getting the remaining number of
      *                                       context based retry attempts.
      */
-    private int getRemainingNumberOfContextBasedRetryAttempts(String tenantDomain, AuthenticationContext context)
+    private int getRemainingNumberOfContextBasedRetryAttempts(AuthenticationContext context)
             throws AuthenticationFailedException {
 
         int maxRetryAttempts = getMaximumRetryAttempts(context.getTenantDomain(), context);

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -69,7 +69,6 @@ public class AuthenticatorConstants {
     // Runtime Params.
     public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
     public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
-    public static final String SKIP_RESEND_BLOCK_TIME = "skipResendBlockTime";
     public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
 
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -35,6 +35,9 @@ public class AuthenticatorConstants {
     public static final String FAILED_LOGIN_ATTEMPTS_CLAIM_URI = "http://wso2.org/claims/identity/failedLoginAttempts";
     public static final String HIDE_USER_EXISTENCE_CONFIG = "LocalAuthenticators.HideUserExistenceOnAuthFlow";
     public static final String MULTIPLE_USERS_ERROR_MESSAGE = "There are more than one user with the provided username";
+    public static final String UNKNOWN_USER = "Unknown user";
+    public static final String DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME = "otpResendAttempts";
+    public static final String DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME = "otpRetryAttempts";
 
     // OTP generation.
     public static final String OTP_NUMERIC_CHAR_SET = "9245378016";
@@ -43,7 +46,6 @@ public class AuthenticatorConstants {
     public static final String CODE = "OTPcode";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP = "otp";
-    public static final String OTP_RESEND_ATTEMPTS = "otpResendAttempts";
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
 
     // Query params.
@@ -63,6 +65,29 @@ public class AuthenticatorConstants {
     public static final String RECAPTCHA_PARAM = "&reCaptcha=";
     public static final String USERNAME_PARAM = "&username=";
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+
+    // Runtime Params.
+    public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
+    public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
+    public static final String SKIP_RESEND_BLOCK_TIME = "skipResendBlockTime";
+    public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
+
+
+    /**
+     * Logging constants for the authenticator.
+     */
+    public static class LogConstants {
+
+        /**
+         * Action IDs for the authenticator.
+         */
+        public static class ActionID {
+
+            public static final String GET_OPTIONAL_INTEGER_RUNTIME_PARAMS = "get-optional-int-from-runtime-param";
+            public static final String GET_MAX_FAILURE_LIMIT = "get-max-failure-limit";
+            public static final String GET_MAX_RESEND_LIMIT = "get-max-resend-limit";
+        }
+    }
 
     /**
      * User claim related constants.
@@ -142,7 +167,9 @@ public class AuthenticatorConstants {
         ERROR_CODE_ERROR_GETTING_OTP_RESEND_ATTEMPTS("65034",
                 "Error occurred while getting OTP resend attempts for user: %s"),
         ERROR_CODE_ERROR_CHECKING_USER_EXISTENCE("65035",
-                "Error occurred while checking existence of user: %s");
+                "Error occurred while checking existence of user: %s"),
+        ERROR_CODE_RESEND_LIMIT_EXCEEDED("65036", "Resend limit exceeded for user: %s"),
+        ERROR_CODE_RETRY_LIMIT_EXCEEDED("65037", "Retry limit exceeded for user: %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -46,6 +46,7 @@ public class AuthenticatorConstants {
     public static final String CODE = "OTPcode";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP = "otp";
+    public static final String OTP_RESEND_ATTEMPTS = "otpResendAttempts";
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
 
     // Query params.
@@ -70,7 +71,6 @@ public class AuthenticatorConstants {
     public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
     public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
     public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
-
 
     /**
      * Logging constants for the authenticator.

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.auth.otp.core.util;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -26,7 +28,13 @@ import org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.auth.otp.core.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 
+import org.wso2.carbon.utils.DiagnosticLog;
+
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MULTI_OPTION_URI_PARAM;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
@@ -37,6 +45,9 @@ import static org.wso2.carbon.identity.handler.event.account.lock.constants.Acco
  * Utility functions for the authenticator.
  */
 public class AuthenticatorUtils {
+
+    private static final Log LOG = LogFactory.getLog(AuthenticatorUtils.class);
+    private static final String COMPONENT_ID = "auth-otp-core-authenticator-utils";
 
     /**
      * Get the multi option URI query param.
@@ -87,4 +98,103 @@ public class AuthenticatorUtils {
         }
         return connectorConfigs;
     }
+
+    /**
+     * Get the parameter value from the runtime parameters if available.
+     *
+     * @param runtimeParams Runtime parameters.
+     * @param paramName     Parameter name.
+     * @return Optional parameter value.
+     */
+    public static Optional<String> getOptionalParamFromRuntimeParams(Map<String, String> runtimeParams,
+                                                                     String paramName) {
+
+        if (runtimeParams == null || runtimeParams.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String value = runtimeParams.get(paramName);
+        if (value != null) {
+            return Optional.of(value);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Get the boolean parameter value from the runtime parameters if available.
+     *
+     * @param runtimeParams Runtime parameters.
+     * @param paramName     Parameter name.
+     * @return Optional boolean parameter value.
+     */
+    public static Optional<Boolean> getOptionalBooleanParamFromRuntimeParams(Map<String, String> runtimeParams,
+                                                                             String paramName) {
+
+        Optional<String> paramValue = getOptionalParamFromRuntimeParams(runtimeParams, paramName);
+        if (paramValue.isPresent()) {
+            String value = paramValue.get();
+            return Optional.of(Boolean.parseBoolean(value));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Get the integer parameter value from the runtime parameters if available.
+     *
+     * @param runtimeParams Runtime parameters.
+     * @param paramName     Parameter name.
+     * @return Optional integer parameter value.
+     */
+    public static OptionalInt getOptionalIntParamFromRuntimeParams(Map<String, String> runtimeParams,
+                                                                   String paramName) {
+
+        if (runtimeParams == null || runtimeParams.isEmpty()) {
+            return OptionalInt.empty();
+        }
+
+        String value = runtimeParams.get(paramName);
+        if (value != null) {
+            try {
+                return OptionalInt.of(Integer.parseInt(value));
+            } catch (NumberFormatException e) {
+                logDiagnostic(
+                        COMPONENT_ID,
+                        AuthenticatorConstants.LogConstants.ActionID.GET_OPTIONAL_INTEGER_RUNTIME_PARAMS,
+                        "Unable to parse the parameter: " + paramName + " with value: "
+                                + value + " to an integer. Returning empty optional.",
+                        DiagnosticLog.ResultStatus.FAILED,
+                        DiagnosticLog.LogDetailLevel.APPLICATION
+                );
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Unable to parse the parameter: " + paramName + " with value: "
+                            + value + " to an integer.", e);
+                }
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Trigger a diagnostic log event if diagnostic logging is enabled.
+     *
+     * @param componentId    The diagnostic log component ID.
+     * @param actionId       The action ID associated with the log event.
+     * @param message        The result message to include in the log.
+     * @param status         The result status of the operation.
+     * @param logDetailLevel The detail level of the log entry.
+     */
+    public static void logDiagnostic(String componentId, String actionId, String message,
+                                     DiagnosticLog.ResultStatus status,
+                                     DiagnosticLog.LogDetailLevel logDetailLevel) {
+
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            LoggerUtils.triggerDiagnosticLogEvent(
+                    new DiagnosticLog.DiagnosticLogBuilder(componentId, actionId)
+                            .resultMessage(message)
+                            .logDetailLevel(logDetailLevel)
+                            .resultStatus(status)
+            );
+        }
+    }
 }
+

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtils.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.auth.otp.core.util;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.owasp.encoder.Encode;
@@ -27,7 +29,6 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.auth.otp.core.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import javax.servlet.http.HttpServletRequest;
@@ -106,15 +107,15 @@ public class AuthenticatorUtils {
      * @param paramName     Parameter name.
      * @return Optional parameter value.
      */
-    public static Optional<String> getOptionalParamFromRuntimeParams(Map<String, String> runtimeParams,
-                                                                     String paramName) {
+    public static Optional<String> getStringRuntimeParamByName(Map<String, String> runtimeParams,
+                                                               String paramName) {
 
-        if (runtimeParams == null || runtimeParams.isEmpty()) {
+        if (MapUtils.isEmpty(runtimeParams)) {
             return Optional.empty();
         }
 
         String value = runtimeParams.get(paramName);
-        if (value != null) {
+        if (StringUtils.isNotBlank(value)) {
             return Optional.of(value);
         }
         return Optional.empty();
@@ -127,10 +128,10 @@ public class AuthenticatorUtils {
      * @param paramName     Parameter name.
      * @return Optional boolean parameter value.
      */
-    public static Optional<Boolean> getOptionalBooleanParamFromRuntimeParams(Map<String, String> runtimeParams,
-                                                                             String paramName) {
+    public static Optional<Boolean> getBooleanRuntimeParamByName(Map<String, String> runtimeParams,
+                                                                 String paramName) {
 
-        Optional<String> paramValue = getOptionalParamFromRuntimeParams(runtimeParams, paramName);
+        Optional<String> paramValue = getStringRuntimeParamByName(runtimeParams, paramName);
         if (paramValue.isPresent()) {
             String value = paramValue.get();
             return Optional.of(Boolean.parseBoolean(value));
@@ -145,19 +146,15 @@ public class AuthenticatorUtils {
      * @param paramName     Parameter name.
      * @return Optional integer parameter value.
      */
-    public static OptionalInt getOptionalIntParamFromRuntimeParams(Map<String, String> runtimeParams,
-                                                                   String paramName) {
+    public static OptionalInt getIntRuntimeParamByName(Map<String, String> runtimeParams,
+                                                       String paramName) {
 
-        if (runtimeParams == null || runtimeParams.isEmpty()) {
-            return OptionalInt.empty();
-        }
-
-        String value = runtimeParams.get(paramName);
-        if (value != null) {
+        Optional<String> value = getStringRuntimeParamByName(runtimeParams, paramName);
+        if (value.isPresent()) {
             try {
-                return OptionalInt.of(Integer.parseInt(value));
+                return OptionalInt.of(Integer.parseInt(value.get()));
             } catch (NumberFormatException e) {
-                logDiagnostic(
+                triggerDiagnosticLog(
                         COMPONENT_ID,
                         AuthenticatorConstants.LogConstants.ActionID.GET_OPTIONAL_INTEGER_RUNTIME_PARAMS,
                         "Unable to parse the parameter: " + paramName + " with value: "
@@ -183,9 +180,9 @@ public class AuthenticatorUtils {
      * @param status         The result status of the operation.
      * @param logDetailLevel The detail level of the log entry.
      */
-    public static void logDiagnostic(String componentId, String actionId, String message,
-                                     DiagnosticLog.ResultStatus status,
-                                     DiagnosticLog.LogDetailLevel logDetailLevel) {
+    public static void triggerDiagnosticLog(String componentId, String actionId, String message,
+                                            DiagnosticLog.ResultStatus status,
+                                            DiagnosticLog.LogDetailLevel logDetailLevel) {
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             LoggerUtils.triggerDiagnosticLogEvent(

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.otp.core;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants;
+import org.wso2.carbon.identity.auth.otp.core.internal.AuthenticatorDataHolder;
+import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.CODE;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_ALLOWED_FAILURE_LIMIT;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_RESEND_LIMIT;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RESEND;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.USERNAME;
+
+/**
+ * Full-flow tests for {@link AbstractOTPAuthenticator}: process(), initiateAuthenticationRequest,
+ * processAuthenticationResponse and context-based retry/resend control logic.
+ */
+public class AbstractOTPAuthenticatorFlowTest {
+
+    private static final String ERROR_CODE_PREFIX = "OTP";
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final String TEST_USER = "testuser";
+    private static final String AUTHENTICATOR_NAME = "FlowTestOTPAuthenticator";
+
+    private static final int TEST_TENANT_ID = -1234;
+
+    private FlowTestOTPAuthenticator authenticator;
+    private MockedStatic<LoggerUtils> loggerUtilsMockedStatic;
+    private MockedStatic<AuthenticatorDataHolder> dataHolderMockedStatic;
+    private MockedStatic<FrameworkUtils> frameworkUtilsMockedStatic;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic;
+    private MockedStatic<CaptchaUtil> captchaUtilMockedStatic;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        authenticator = new FlowTestOTPAuthenticator();
+        loggerUtilsMockedStatic = mockStatic(LoggerUtils.class);
+        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+        dataHolderMockedStatic = mockStatic(AuthenticatorDataHolder.class);
+        AccountLockService accountLockService = mock(AccountLockService.class);
+        when(accountLockService.isAccountLocked(anyString(), anyString(), anyString())).thenReturn(false);
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getAccountLockService).thenReturn(accountLockService);
+
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        doNothing().when(identityEventService).handleEvent(any());
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getIdentityEventService).thenReturn(identityEventService);
+
+        UserRealm userRealm = mock(UserRealm.class);
+        UserStoreManager userStoreManager = mock(UserStoreManager.class);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        RealmService realmService = mock(RealmService.class);
+        when(realmService.getTenantUserRealm(TEST_TENANT_ID)).thenReturn(userRealm);
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getRealmService).thenReturn(realmService);
+
+        identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
+        identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(TEST_TENANT_ID);
+
+        frameworkUtilsMockedStatic = mockStatic(FrameworkUtils.class);
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.getQueryStringWithFrameworkContextId(any(), any(), any()))
+                .thenReturn("");
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.appendQueryParamsStringToUrl(anyString(), anyString()))
+                .thenAnswer(inv -> inv.getArgument(0) + "?" + inv.getArgument(1));
+
+        captchaUtilMockedStatic = mockStatic(CaptchaUtil.class);
+        captchaUtilMockedStatic.when(CaptchaUtil::isReCaptchaEnabled).thenReturn(false);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (loggerUtilsMockedStatic != null) {
+            loggerUtilsMockedStatic.close();
+        }
+        if (dataHolderMockedStatic != null) {
+            dataHolderMockedStatic.close();
+        }
+        if (frameworkUtilsMockedStatic != null) {
+            frameworkUtilsMockedStatic.close();
+        }
+        if (identityTenantUtilMockedStatic != null) {
+            identityTenantUtilMockedStatic.close();
+        }
+        if (captchaUtilMockedStatic != null) {
+            captchaUtilMockedStatic.close();
+        }
+    }
+
+    @Test(description = "process() with LOGOUT scenario returns SUCCESS_COMPLETED")
+    public void testProcess_LogoutScenario_ReturnsSuccessCompleted()
+            throws AuthenticationFailedException, org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AuthenticationContext context = new AuthenticationContext();
+        context.setLogoutRequest(true);
+
+        AuthenticatorFlowStatus status = authenticator.process(request, response, context);
+
+        Assert.assertEquals(status, AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+    }
+
+    @Test(description = "process() with INITIAL_OTP scenario returns INCOMPLETE and initiates OTP flow")
+    public void testProcess_InitialOtpScenario_ReturnsIncompleteAndSetsOtpInContext()
+            throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(false);
+        context.setCurrentStep(1);
+
+        AuthenticatorFlowStatus status = authenticator.process(request, response, context);
+
+        Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+        Assert.assertNotNull(context.getProperty(OTP), "OTP should be set in context after initiateAuthenticationRequest");
+    }
+
+    @Test(description = "process() with SUBMIT_OTP and valid OTP returns SUCCESS_COMPLETED and resets retry/resend counts")
+    public void testProcess_SubmitOtp_ValidOtp_SuccessCompleted_ResetsCounts()
+            throws Exception {
+
+        String otpValue = "123456";
+        OTP otp = new OTP(otpValue, System.currentTimeMillis(), 300_000L);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(otpValue);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getAttribute(FrameworkConstants.REQ_ATTR_HANDLED)).thenReturn(null);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(true);
+        context.setCurrentStep(1);
+        context.setProperty(OTP, otp);
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
+
+        authenticator.setCanHandle(true);
+
+        AuthenticatorFlowStatus status = authenticator.process(request, response, context);
+
+        Assert.assertEquals(status, AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 0,
+                "Retry count should be reset on success");
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME), 0,
+                "Resend count should be reset on success");
+    }
+
+    @Test(description = "processAuthenticationResponse with invalid OTP and context-based retry enabled increments retry count (tests same logic as SUBMIT_OTP path)")
+    public void testProcess_SubmitOtp_InvalidOtp_ContextRetryEnabled_IncrementsRetryCount()
+            throws Exception {
+
+        OTP otp = new OTP("123456", System.currentTimeMillis(), 300_000L);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn("wrong");
+        when(request.getParameter(RESEND)).thenReturn(null);
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setProperty(OTP, otp);
+        context.setTenantDomain(TENANT_DOMAIN);
+
+        try {
+            authenticator.processAuthenticationResponse(request, response, context);
+            Assert.fail("Expected AuthenticationFailedException for invalid OTP");
+        } catch (AuthenticationFailedException e) {
+            // Expected.
+        }
+        Object retryCountObj = context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+        Assert.assertNotNull(retryCountObj, "Context retry count should be set when context-based retry is enabled");
+        Assert.assertEquals(Integer.parseInt(retryCountObj.toString()), 1,
+                "Context retry count should be incremented after invalid OTP");
+    }
+
+    @Test(description = "processAuthenticationResponse with invalid OTP when retry limit exceeded sets SKIP_RETRY and AUTH_ERROR_CODE (tests same logic as SUBMIT_OTP path)")
+    public void testProcess_SubmitOtp_InvalidOtp_RetryLimitExceeded_SkipsRetryAndSetsErrorCode()
+            throws Exception {
+
+        OTP otp = new OTP("123456", System.currentTimeMillis(), 300_000L);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn("wrong");
+        when(request.getParameter(RESEND)).thenReturn(null);
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_ALLOWED_FAILURE_LIMIT, "2");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setProperty(OTP, otp);
+        context.setTenantDomain(TENANT_DOMAIN);
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
+
+        try {
+            authenticator.processAuthenticationResponse(request, response, context);
+            Assert.fail("Expected AuthenticationFailedException for invalid OTP");
+        } catch (AuthenticationFailedException e) {
+            // Expected.
+        }
+        Object retryCountObj = context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+        Assert.assertNotNull(retryCountObj);
+        Assert.assertEquals(Integer.parseInt(retryCountObj.toString()), 2);
+        Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+        Assert.assertNotNull(context.getProperty(AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR));
+    }
+
+    @Test(description = "process() with RESEND_OTP and resend limit not exceeded increments resend count in initiate path")
+    public void testProcess_ResendOtp_UnderLimit_IncrementsResendCount()
+            throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn("true");
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_RESEND_LIMIT, "5");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(true);
+        context.setCurrentStep(1);
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 0);
+
+        Assert.assertEquals(authenticator.process(request, response, context), AuthenticatorFlowStatus.INCOMPLETE);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 1,
+                "Resend count should be incremented on RESEND_OTP");
+    }
+
+    @Test(description = "process() with RESEND_OTP and resend limit exceeded with terminate=true sets AUTH_ERROR_CODE and throws")
+    public void testProcess_ResendOtp_ResendLimitExceeded_Terminate_SetsErrorCodeAndThrows()
+            throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn("true");
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_RESEND_LIMIT, "2");
+        runtimeParams.put(AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED, "true");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(true);
+        context.setCurrentStep(1);
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+
+        try {
+            authenticator.process(request, response, context);
+            Assert.fail("Expected AuthenticationFailedException when resend limit exceeded with terminate=true");
+        } catch (AuthenticationFailedException e) {
+            Assert.assertNotNull(e.getErrorCode());
+        }
+        Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED);
+    }
+
+    @Test(description = "initiateAuthenticationRequest sets OTP in context and updates resend count on RESEND_OTP")
+    public void testInitiateAuthenticationRequest_ResendOtp_UpdatesResendCount()
+            throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn("true");
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_RESEND_LIMIT, "5");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(true);
+        context.setCurrentStep(1);
+
+        authenticator.initiateAuthenticationRequest(request, response, context);
+
+        Assert.assertNotNull(context.getProperty(OTP));
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 1);
+    }
+
+    @Test(description = "processAuthenticationResponse with invalid OTP calls handleInvalidOTPLoginAttempt and increments retry when enabled")
+    public void testProcessAuthenticationResponse_InvalidOtp_IncrementsRetryWhenEnabled()
+            throws Exception {
+
+        OTP otp = new OTP("123456", System.currentTimeMillis(), 300_000L);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn("wrong");
+        when(request.getParameter(RESEND)).thenReturn(null);
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setProperty(OTP, otp);
+        context.setTenantDomain(TENANT_DOMAIN);
+
+        try {
+            authenticator.processAuthenticationResponse(request, response, context);
+            Assert.fail("Expected AuthenticationFailedException for invalid OTP");
+        } catch (AuthenticationFailedException e) {
+            Assert.assertTrue(e.getMessage().contains(AuthenticatorConstants.ErrorMessages.ERROR_CODE_OTP_INVALID.getMessage())
+                    || e.getErrorCode() != null);
+        }
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 1);
+    }
+
+    @Test(description = "processAuthenticationResponse with valid OTP resets retry and resend counts")
+    public void testProcessAuthenticationResponse_ValidOtp_ResetsCounts()
+            throws Exception {
+
+        String otpValue = "123456";
+        OTP otp = new OTP(otpValue, System.currentTimeMillis(), 300_000L);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(otpValue);
+        when(request.getParameter(RESEND)).thenReturn(null);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setProperty(OTP, otp);
+        context.setTenantDomain(TENANT_DOMAIN);
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
+
+        authenticator.processAuthenticationResponse(request, response, context);
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 0);
+    }
+
+    private AuthenticationContext createContextWithAuthenticatedUser(String username) {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(TENANT_DOMAIN);
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        ApplicationConfig appConfig = mock(ApplicationConfig.class);
+        when(appConfig.isSaaSApp()).thenReturn(true);
+        sequenceConfig.setApplicationConfig(appConfig);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setOrder(1);
+        stepConfig.setSubjectAttributeStep(true);
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName(username);
+        user.setTenantDomain(TENANT_DOMAIN);
+        user.setUserStoreDomain("PRIMARY");
+        stepConfig.setAuthenticatedUser(user);
+        context.setSubject(user);
+
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        sequenceConfig.setStepMap(stepMap);
+        context.setSequenceConfig(sequenceConfig);
+        context.setCurrentStep(1);
+        context.setProperty(FrameworkConstants.AnalyticsData.DATA_MAP, new HashMap<String, Serializable>());
+
+        return context;
+    }
+
+    /**
+     * Test authenticator that allows configuring canHandle and runtime params for flow tests.
+     */
+    private static class FlowTestOTPAuthenticator extends AbstractOTPAuthenticator {
+
+        private Map<String, String> runtimeParams = new HashMap<>();
+        private boolean canHandle = false;
+
+        void setRuntimeParams(Map<String, String> params) {
+
+            this.runtimeParams = params != null ? params : new HashMap<>();
+        }
+
+        void setCanHandle(boolean canHandle) {
+
+            this.canHandle = canHandle;
+        }
+
+        @Override
+        public Map<String, String> getRuntimeParams(AuthenticationContext context) {
+
+            return runtimeParams;
+        }
+
+        @Override
+        public boolean canHandle(HttpServletRequest request) {
+
+            return canHandle;
+        }
+
+        @Override
+        protected String getAuthenticatorErrorPrefix() {
+
+            return ERROR_CODE_PREFIX;
+        }
+
+        @Override
+        protected void sendOtp(AuthenticatedUser authenticatedUser, OTP otp, boolean isInitialFederationAttempt,
+                               HttpServletRequest request, HttpServletResponse response,
+                               AuthenticationContext context) {
+        }
+
+        @Override
+        protected String getMaskedUserClaimValue(AuthenticatedUser authenticatedUser, String tenantDomain,
+                                                 boolean isInitialFederationAttempt, AuthenticationContext context) {
+
+            return "***";
+        }
+
+        @Override
+        protected void publishPostOTPValidatedEvent(OTP otpInfo, AuthenticatedUser authenticatedUser,
+                                                    boolean isAuthenticationPassed, boolean isExpired,
+                                                    HttpServletRequest request, AuthenticationContext context) {
+        }
+
+        @Override
+        protected void publishPostOTPGeneratedEvent(OTP otpInfo, AuthenticatedUser authenticatedUser,
+                                                    HttpServletRequest request, AuthenticationContext context) {
+        }
+
+        @Override
+        protected String getErrorPageURL(AuthenticationContext context) {
+
+            return "https://localhost/error.do";
+        }
+
+        @Override
+        protected String getOTPLoginPageURL(AuthenticationContext context) {
+
+            return "https://localhost/otp.jsp";
+        }
+
+        @Override
+        public String getContextIdentifier(HttpServletRequest request) {
+
+            return "ctx1";
+        }
+
+        @Override
+        public String getName() {
+
+            return AUTHENTICATOR_NAME;
+        }
+
+        @Override
+        public String getFriendlyName() {
+
+            return "Flow Test OTP";
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
@@ -120,8 +120,6 @@ public class AbstractOTPAuthenticatorTest {
      */
     private static class TestOTPAuthenticator extends AbstractOTPAuthenticator {
 
-        private Map<String, String> runtimeParams;
-
         @Override
         protected String getAuthenticatorErrorPrefix() {
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -115,8 +116,11 @@ public class AbstractOTPAuthenticatorTest {
 
     /**
      * Test implementation of {@link AbstractOTPAuthenticator} with stubbed abstract behaviours.
+     * Includes a configurable runtime params map to simulate authenticator parameters.
      */
     private static class TestOTPAuthenticator extends AbstractOTPAuthenticator {
+
+        private Map<String, String> runtimeParams;
 
         @Override
         protected String getAuthenticatorErrorPrefix() {

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
@@ -1,0 +1,863 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.otp.core;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants;
+import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_ALLOWED_FAILURE_LIMIT;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_RESEND_LIMIT;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SKIP_RESEND_BLOCK_TIME;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED;
+
+/**
+ * Unit tests for context-based OTP resend/retry control in AbstractOTPAuthenticator.
+ */
+public class ContextBasedOTPControlTest {
+
+    private static final String ERROR_CODE_PREFIX = "OTP";
+    private static final String TENANT_DOMAIN = "carbon.super";
+
+    private TestOTPAuthenticator authenticator;
+    private MockedStatic<LoggerUtils> loggerUtilsMockedStatic;
+
+    @BeforeMethod
+    public void setUp() {
+
+        authenticator = new TestOTPAuthenticator();
+        loggerUtilsMockedStatic = mockStatic(LoggerUtils.class);
+        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (loggerUtilsMockedStatic != null) {
+            loggerUtilsMockedStatic.close();
+        }
+    }
+
+    @Test(description = "Context-based resend blocking is enabled when MAXIMUM_RESEND_LIMIT param is a non-negative integer")
+    public void testIsContextBasedOTPResendBlockingEnabled_WithValidPositiveLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "3");
+        Assert.assertTrue(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based resend blocking is enabled when MAXIMUM_RESEND_LIMIT param is zero (zero resends allowed)")
+    public void testIsContextBasedOTPResendBlockingEnabled_WithZeroLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "0");
+        Assert.assertTrue(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based resend blocking is disabled when MAXIMUM_RESEND_LIMIT param is negative")
+    public void testIsContextBasedOTPResendBlockingEnabled_WithNegativeLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "-1");
+        Assert.assertFalse(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based resend blocking is disabled when MAXIMUM_RESEND_LIMIT param is absent")
+    public void testIsContextBasedOTPResendBlockingEnabled_WithNoParam()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        Assert.assertFalse(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based resend blocking is disabled when MAXIMUM_RESEND_LIMIT param is non-numeric")
+    public void testIsContextBasedOTPResendBlockingEnabled_WithNonNumericLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "invalid");
+        // Non-numeric cannot be parsed to int, so OptionalInt is empty → returns false
+        Assert.assertFalse(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based retry blocking is enabled when MAXIMUM_ALLOWED_FAILURE_LIMIT is a positive integer")
+    public void testIsContextBasedRetryBlockingEnabled_WithValidPositiveLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        Assert.assertTrue(authenticator.isContextBasedRetryBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based retry blocking is disabled when MAXIMUM_ALLOWED_FAILURE_LIMIT is zero (must be > 0)")
+    public void testIsContextBasedRetryBlockingEnabled_WithZeroLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "0");
+        Assert.assertFalse(authenticator.isContextBasedRetryBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based retry blocking is disabled when MAXIMUM_ALLOWED_FAILURE_LIMIT is negative")
+    public void testIsContextBasedRetryBlockingEnabled_WithNegativeLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "-2");
+        Assert.assertFalse(authenticator.isContextBasedRetryBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based retry blocking is disabled when MAXIMUM_ALLOWED_FAILURE_LIMIT param is absent")
+    public void testIsContextBasedRetryBlockingEnabled_WithNoParam()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        Assert.assertFalse(authenticator.isContextBasedRetryBlockingEnabled(context));
+    }
+
+    @Test(description = "Context-based retry blocking is disabled when MAXIMUM_ALLOWED_FAILURE_LIMIT is non-numeric")
+    public void testIsContextBasedRetryBlockingEnabled_WithNonNumericLimit()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "abc");
+        Assert.assertFalse(authenticator.isContextBasedRetryBlockingEnabled(context));
+    }
+
+    @Test(description = "isTerminateOnResendLimitExceeded returns true when param is 'true'")
+    public void testIsTerminateOnResendLimitExceeded_WhenTrue()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                TERMINATE_ON_RESEND_LIMIT_EXCEEDED, "true");
+        Assert.assertTrue(authenticator.isTerminateOnResendLimitExceeded(context));
+    }
+
+    @Test(description = "isTerminateOnResendLimitExceeded returns false when param is 'false'")
+    public void testIsTerminateOnResendLimitExceeded_WhenFalse()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                TERMINATE_ON_RESEND_LIMIT_EXCEEDED, "false");
+        Assert.assertFalse(authenticator.isTerminateOnResendLimitExceeded(context));
+    }
+
+    @Test(description = "isTerminateOnResendLimitExceeded returns false when param is absent")
+    public void testIsTerminateOnResendLimitExceeded_WhenAbsent()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        Assert.assertFalse(authenticator.isTerminateOnResendLimitExceeded(context));
+    }
+
+    @Test(description = "User-based resend blocking is disabled when skipResendBlockTime runtime param is 'true'")
+    public void testIsUserBasedOTPResendBlockingEnabled_SkipResendBlockTimeTrue()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                SKIP_RESEND_BLOCK_TIME, "true");
+
+        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == true
+        // => return !true => false
+        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "User-based resend blocking is enabled when skipResendBlockTime runtime param is 'false'")
+    public void testIsUserBasedOTPResendBlockingEnabled_SkipResendBlockTimeFalse()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                SKIP_RESEND_BLOCK_TIME, "false");
+
+        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == false
+        // => return !false => true
+        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "User-based resend blocking falls back to default (false) when skipResendBlockTime is absent")
+    public void testIsUserBasedOTPResendBlockingEnabled_NoOverride()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+
+        // No override → falls back to isUserBasedOTPResendBlockingEnabled() which returns false by default
+        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
+    }
+
+    @Test(description = "updateContextOTPResendCount initialises the counter to 1 when not set")
+    public void testUpdateContextOTPResendCount_InitialisesToOne() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        authenticator.updateContextOTPResendCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME), 1);
+    }
+
+    @Test(description = "updateContextOTPResendCount increments existing counter")
+    public void testUpdateContextOTPResendCount_Increments() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        authenticator.updateContextOTPResendCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME), 3);
+    }
+
+    @Test(description = "updateContextOTPRetryCount initialises the counter to 1 when not set")
+    public void testUpdateContextOTPRetryCount_InitialisesToOne() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 1);
+    }
+
+    @Test(description = "updateContextOTPRetryCount increments existing counter")
+    public void testUpdateContextOTPRetryCount_Increments() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 4);
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 5);
+    }
+
+    @Test(description = "resetContextResendCount sets counter to 0")
+    public void testResetContextResendCount() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 3);
+        authenticator.resetContextResendCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME), 0);
+    }
+
+    @Test(description = "resetContextRetryCount sets counter to 0")
+    public void testResetContextRetryCount() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 7);
+        authenticator.resetContextRetryCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 0);
+    }
+
+    @Test(description = "getCurrentResendAttempt returns 0 when counter is not set")
+    public void testGetCurrentResendAttempt_WhenNotSet() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 0);
+    }
+
+    @Test(description = "getCurrentResendAttempt returns the stored counter value")
+    public void testGetCurrentResendAttempt_WhenSet() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 2);
+    }
+
+    @Test(description = "getCurrentRetryAttempt returns 0 when counter is not set")
+    public void testGetCurrentRetryAttempt_WhenNotSet() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+    }
+
+    @Test(description = "getCurrentRetryAttempt returns the stored counter value")
+    public void testGetCurrentRetryAttempt_WhenSet() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 3);
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 3);
+    }
+
+    @Test(description = "Counter is 0 when the context property is blank string")
+    public void testGetCurrentRetryAttempt_WhenBlankString() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "");
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+    }
+
+    @Test(description = "updateContextOTPRetryCount initialises to 1 when the property is blank string")
+    public void testUpdateContextOTPRetryCount_WhenBlankString() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "");
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 1);
+    }
+
+    @Test(description = "getResendAttemptsPropertyKey returns the default context property name")
+    public void testGetResendAttemptsPropertyKey() {
+
+        Assert.assertEquals(
+                authenticator.getResendAttemptsPropertyKey(),
+                DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+    }
+
+    @Test(description = "getRetryAttemptsPropertyKey returns the default context property name")
+    public void testGetRetryAttemptsPropertyKey() {
+
+        Assert.assertEquals(
+                authenticator.getRetryAttemptsPropertyKey(),
+                DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+    }
+
+    @Test(description = "getMaximumResendAttempts returns context runtime param value when context-based blocking is enabled")
+    public void testGetMaximumResendAttempts_WithContextParam()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "7");
+        int result = authenticator.getMaximumResendAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, 7);
+    }
+
+    @Test(description = "getMaximumResendAttempts falls back to default when context-based blocking is disabled")
+    public void testGetMaximumResendAttempts_FallsBackToDefault_WhenContextBlockingDisabled()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        int result = authenticator.getMaximumResendAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS);
+    }
+
+    @Test(description = "getMaximumResendAttempts with negative MAXIMUM_RESEND_LIMIT falls back to default")
+    public void testGetMaximumResendAttempts_WithNegativeContextParam_FallsBackToDefault()
+            throws AuthenticationFailedException {
+
+        // Negative value means context-based blocking is disabled, so falls back to default.
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_RESEND_LIMIT, "-1");
+        int result = authenticator.getMaximumResendAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS);
+    }
+
+    @Test(description = "getMaximumRetryAttempts returns context runtime param value when context-based blocking is enabled")
+    public void testGetMaximumRetryAttempts_WithContextParam()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "4");
+        int result = authenticator.getMaximumRetryAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, 4);
+    }
+
+    @Test(description = "getMaximumRetryAttempts returns Integer.MAX_VALUE when context-based blocking is disabled")
+    public void testGetMaximumRetryAttempts_FallsBackToMaxInt_WhenContextBlockingDisabled()
+            throws AuthenticationFailedException {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        int result = authenticator.getMaximumRetryAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, Integer.MAX_VALUE);
+    }
+
+    @Test(description = "getMaximumRetryAttempts returns Integer.MAX_VALUE when MAXIMUM_ALLOWED_FAILURE_LIMIT is zero (blocking disabled)")
+    public void testGetMaximumRetryAttempts_WithZeroLimit_ReturnsMaxInt()
+            throws AuthenticationFailedException {
+
+        // Zero is invalid for retry (must be > 0), so context-based blocking is disabled
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "0");
+        int result = authenticator.getMaximumRetryAttempts(TENANT_DOMAIN, context);
+        Assert.assertEquals(result, Integer.MAX_VALUE);
+    }
+
+    @Test(description = "handleOTPRetryCountExceededScenario sets SKIP_RETRY_FROM_AUTHENTICATOR=true and AUTH_ERROR_CODE")
+    public void testHandleOTPRetryCountExceededScenario_SetsContextProperties() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        invokePrivateVoidMethod("handleOTPRetryCountExceededScenario",
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
+        Assert.assertNotNull(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE));
+        Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(description = "handleOTPResendCountExceededScenario with terminateFlow=true sets AUTH_ERROR_CODE and throws")
+    public void testHandleOTPResendCountExceededScenario_TerminateFlow_WithUser() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setRetrying(true);
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName("testUser");
+        user.setTenantDomain(TENANT_DOMAIN);
+
+        try {
+            invokePrivateVoidMethod(
+                    "handleOTPResendCountExceededScenario",
+                    new Class[]{HttpServletRequest.class, HttpServletResponse.class,
+                            AuthenticationContext.class, AuthenticatedUser.class, boolean.class},
+                    new Object[]{null, null, context, user, true});
+            Assert.fail("Expected AuthenticationFailedException was not thrown");
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue(cause instanceof AuthenticationFailedException,
+                    "Expected AuthenticationFailedException but got: " + cause.getClass().getName());
+            Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                    FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED);
+            Assert.assertFalse(context.isRetrying(),
+                    "context.isRetrying() should be false after terminate-flow path");
+        }
+    }
+
+    @Test(description = "handleOTPResendCountExceededScenario with terminateFlow=true and null user throws with UNKNOWN_USER")
+    public void testHandleOTPResendCountExceededScenario_TerminateFlow_WithNullUser() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setRetrying(true);
+
+        try {
+            invokePrivateVoidMethod(
+                    "handleOTPResendCountExceededScenario",
+                    new Class[]{HttpServletRequest.class, HttpServletResponse.class,
+                            AuthenticationContext.class, AuthenticatedUser.class, boolean.class},
+                    new Object[]{null, null, context, null, true});
+            Assert.fail("Expected AuthenticationFailedException was not thrown");
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue(cause instanceof AuthenticationFailedException,
+                    "Expected AuthenticationFailedException but got: " + cause.getClass().getName());
+            AuthenticationFailedException authEx = (AuthenticationFailedException) cause;
+            Assert.assertTrue(authEx.getMessage().contains(AuthenticatorConstants.UNKNOWN_USER),
+                    "Error message should reference UNKNOWN_USER. Actual: " + authEx.getMessage());
+            Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                    FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Test(description = "Full resend counter lifecycle: init, increment, read, reset")
+    public void testResendCounterFullLifecycle() {
+
+        AuthenticationContext context = new AuthenticationContext();
+
+        // Initially zero
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 0);
+
+        // First update → 1
+        authenticator.updateContextOTPResendCount(context);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 1);
+
+        // Second update → 2
+        authenticator.updateContextOTPResendCount(context);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 2);
+
+        // Third update → 3
+        authenticator.updateContextOTPResendCount(context);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 3);
+
+        // Reset → 0
+        authenticator.resetContextResendCount(context);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 0);
+    }
+
+    @Test(description = "Full retry counter lifecycle: init, increment, read, reset")
+    public void testRetryCounterFullLifecycle() {
+
+        AuthenticationContext context = new AuthenticationContext();
+
+        // Initially zero
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+
+        // First update → 1
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 1);
+
+        // Second update → 2
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 2);
+
+        // Reset → 0
+        authenticator.resetContextRetryCount(context);
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+    }
+
+
+    @Test(description = "isOTPResendLimitExceeded returns true when current resend count equals the limit")
+    public void testIsOTPResendLimitExceeded_WhenAtLimit() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(MAXIMUM_RESEND_LIMIT, "3");
+        // Set current resend count to 3 (= limit)
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 3);
+
+        boolean result = invokePrivateBooleanMethod(
+                "isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "isOTPResendLimitExceeded returns true when current resend count exceeds the limit")
+    public void testIsOTPResendLimitExceeded_WhenExceedsLimit() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(MAXIMUM_RESEND_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 5);
+
+        boolean result = invokePrivateBooleanMethod(
+                "isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "isOTPResendLimitExceeded returns false when current resend count is below the limit")
+    public void testIsOTPResendLimitExceeded_WhenBelowLimit() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(MAXIMUM_RESEND_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
+        boolean result = invokePrivateBooleanMethod(
+                "isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+
+        Assert.assertFalse(result);
+    }
+
+    @Test(description = "isOTPResendLimitExceeded uses default resend attempts when context-based blocking is off")
+    public void testIsOTPResendLimitExceeded_WhenContextBlockingDisabled_UsesDefault() throws Exception {
+
+        // No MAXIMUM_RESEND_LIMIT param → context-based blocking is off → falls back to default (5)
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        // Set count below default (5)
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        boolean result = invokePrivateBooleanMethod(
+                "isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+
+        Assert.assertFalse(result);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt increments retry counter when context-based blocking is enabled")
+    public void testHandleInvalidOTPLoginAttempt_IncrementsCounter() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        invokePrivateVoidMethod(
+                "handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 1);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt does NOT increment retry counter when context-based blocking is disabled")
+    public void testHandleInvalidOTPLoginAttempt_DoesNotIncrementWhenDisabled() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(null, null);
+        invokePrivateVoidMethod(
+                "handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+
+        Assert.assertEquals(authenticator.getCurrentRetryAttempt(context), 0);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt sets AUTH_ERROR_CODE when retry count reaches the limit")
+    public void testHandleInvalidOTPLoginAttempt_SetsErrorCodeWhenLimitReached() throws Exception {
+
+        // Limit = 3, set current = 2 so that after increment it becomes 3 = limit
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        invokePrivateVoidMethod(
+                "handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+        Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt does NOT set AUTH_ERROR_CODE when retry count is below the limit")
+    public void testHandleInvalidOTPLoginAttempt_NoErrorCodeWhenBelowLimit() throws Exception {
+
+        // Limit = 5, current = 0 → after increment becomes 1 < 5
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        invokePrivateVoidMethod(
+                "handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+        Assert.assertNull(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE));
+    }
+
+    @Test(description = "getRemainingNumberOfContextBasedRetryAttempts returns correct remaining count")
+    public void testGetRemainingNumberOfContextBasedRetryAttempts_Normal() throws Exception {
+
+        // max = 5, current = 2 → remaining = 3
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 2);
+        context.setTenantDomain(TENANT_DOMAIN);
+        int remaining = invokePrivateIntMethod(
+                "getRemainingNumberOfContextBasedRetryAttempts",
+                new Class[]{String.class, AuthenticationContext.class},
+                new Object[]{TENANT_DOMAIN, context});
+        Assert.assertEquals(remaining, 3);
+    }
+
+    @Test(description = "getRemainingNumberOfContextBasedRetryAttempts returns 0 when current equals max")
+    public void testGetRemainingNumberOfContextBasedRetryAttempts_WhenAtMax() throws Exception {
+
+        // max = 3, current = 3 → remaining = 0
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 3);
+        context.setTenantDomain(TENANT_DOMAIN);
+        int remaining = invokePrivateIntMethod(
+                "getRemainingNumberOfContextBasedRetryAttempts",
+                new Class[]{String.class, AuthenticationContext.class},
+                new Object[]{TENANT_DOMAIN, context});
+        Assert.assertEquals(remaining, 0);
+    }
+
+    @Test(description = "getRemainingNumberOfContextBasedRetryAttempts returns 0 (not negative) when over limit")
+    public void testGetRemainingNumberOfContextBasedRetryAttempts_WhenOverMax() throws Exception {
+
+        // max = 3, current = 5 → remaining = max(3-5, 0) = 0
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 5);
+        context.setTenantDomain(TENANT_DOMAIN);
+        int remaining = invokePrivateIntMethod(
+                "getRemainingNumberOfContextBasedRetryAttempts",
+                new Class[]{String.class, AuthenticationContext.class},
+                new Object[]{TENANT_DOMAIN, context});
+        Assert.assertEquals(remaining, 0);
+    }
+
+    @Test(description = "Both resend and retry limits can be set simultaneously in runtime params")
+    public void testBothResendAndRetryLimitsCanCoexist() throws AuthenticationFailedException {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(MAXIMUM_RESEND_LIMIT, "3");
+        params.put(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        params.put(TERMINATE_ON_RESEND_LIMIT_EXCEEDED, "true");
+        AuthenticationContext context = createContextWithMultipleRuntimeParams(params);
+        Assert.assertTrue(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+        Assert.assertTrue(authenticator.isContextBasedRetryBlockingEnabled(context));
+        Assert.assertTrue(authenticator.isTerminateOnResendLimitExceeded(context));
+        Assert.assertEquals(authenticator.getMaximumResendAttempts(TENANT_DOMAIN, context), 3);
+        Assert.assertEquals(authenticator.getMaximumRetryAttempts(TENANT_DOMAIN, context), 5);
+    }
+
+    @Test(description = "skipResendBlockTime=true disables user-based blocking regardless of other params")
+    public void testSkipResendBlockTimeOverridesUserBasedBlocking() throws AuthenticationFailedException {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(SKIP_RESEND_BLOCK_TIME, "true");
+        params.put(MAXIMUM_RESEND_LIMIT, "3");
+        AuthenticationContext context = createContextWithMultipleRuntimeParams(params);
+        // User-based blocking is skipped
+        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
+        // Context-based blocking is still enabled independently
+        Assert.assertTrue(authenticator.isContextBasedOTPResendBlockingEnabled(context));
+    }
+
+    /**
+     * Creates an AuthenticationContext with a single runtime parameter injected
+     * through the TestOTPAuthenticator's runtime params map.
+     */
+    private AuthenticationContext createContextWithRuntimeParams(String paramName, String paramValue) {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(TENANT_DOMAIN);
+        if (paramName != null) {
+            Map<String, String> params = new HashMap<>();
+            params.put(paramName, paramValue);
+            authenticator.setRuntimeParams(params);
+        } else {
+            authenticator.setRuntimeParams(new HashMap<>());
+        }
+        return context;
+    }
+
+    /**
+     * Creates an AuthenticationContext with multiple runtime parameters.
+     */
+    private AuthenticationContext createContextWithMultipleRuntimeParams(Map<String, String> params) {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(TENANT_DOMAIN);
+        authenticator.setRuntimeParams(params != null ? params : new HashMap<>());
+        return context;
+    }
+
+    /**
+     * Invokes a private void method on the authenticator via reflection.
+     */
+    private void invokePrivateVoidMethod(String methodName, Class<?>[] paramTypes, Object[] args) throws Exception {
+
+        Method method = findPrivateMethod(AbstractOTPAuthenticator.class, methodName, paramTypes);
+        method.invoke(authenticator, args);
+    }
+
+    /**
+     * Invokes a private boolean method on the authenticator via reflection.
+     */
+    private boolean invokePrivateBooleanMethod(String methodName, Class<?>[] paramTypes, Object[] args)
+            throws Exception {
+
+        Method method = findPrivateMethod(AbstractOTPAuthenticator.class, methodName, paramTypes);
+        return (boolean) method.invoke(authenticator, args);
+    }
+
+    /**
+     * Invokes a private int method on the authenticator via reflection.
+     */
+    private int invokePrivateIntMethod(String methodName, Class<?>[] paramTypes, Object[] args)
+            throws Exception {
+
+        Method method = findPrivateMethod(AbstractOTPAuthenticator.class, methodName, paramTypes);
+        return (int) method.invoke(authenticator, args);
+    }
+
+    /**
+     * Finds a private/protected method, searching up the class hierarchy.
+     */
+    private Method findPrivateMethod(Class<?> clazz, String methodName, Class<?>[] paramTypes) throws Exception {
+
+        try {
+            Method method = clazz.getDeclaredMethod(methodName, paramTypes);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException e) {
+            if (clazz.getSuperclass() != null) {
+                return findPrivateMethod(clazz.getSuperclass(), methodName, paramTypes);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Minimal concrete implementation of {@link AbstractOTPAuthenticator} for unit testing.
+     * Exposes {@code setRuntimeParams} so tests can inject runtime parameters without
+     * needing a full authentication framework context.
+     */
+    private static class TestOTPAuthenticator extends AbstractOTPAuthenticator {
+
+        private Map<String, String> runtimeParams = new HashMap<>();
+
+        /**
+         * Inject runtime parameters that will be returned by {@code getRuntimeParams(context)}.
+         */
+        public void setRuntimeParams(Map<String, String> params) {
+
+            this.runtimeParams = params;
+        }
+
+        @Override
+        public Map<String, String> getRuntimeParams(AuthenticationContext context) {
+
+            return runtimeParams;
+        }
+
+        @Override
+        protected String getAuthenticatorErrorPrefix() {
+
+            return ERROR_CODE_PREFIX;
+        }
+
+        @Override
+        protected void sendOtp(AuthenticatedUser authenticatedUser, OTP otp, boolean isInitialFederationAttempt,
+                               HttpServletRequest request, HttpServletResponse response,
+                               AuthenticationContext context) {
+            // No-op for testing.
+        }
+
+        @Override
+        protected String getMaskedUserClaimValue(AuthenticatedUser authenticatedUser, String tenantDomain,
+                                                 boolean isInitialFederationAttempt,
+                                                 AuthenticationContext context) {
+
+            return "***masked***";
+        }
+
+        @Override
+        protected void publishPostOTPValidatedEvent(OTP otpInfo, AuthenticatedUser authenticatedUser,
+                                                    boolean isAuthenticationPassed, boolean isExpired,
+                                                    HttpServletRequest request, AuthenticationContext context) {
+            // No-op for testing.
+        }
+
+        @Override
+        protected void publishPostOTPGeneratedEvent(OTP otpInfo, AuthenticatedUser authenticatedUser,
+                                                    HttpServletRequest request, AuthenticationContext context) {
+            // No-op for testing.
+        }
+
+        @Override
+        protected String getErrorPageURL(AuthenticationContext context) {
+
+            return "https://localhost:9443/authenticationendpoint/error.do";
+        }
+
+        @Override
+        protected String getOTPLoginPageURL(AuthenticationContext context) {
+
+            return "https://localhost:9443/authenticationendpoint/otp.jsp";
+        }
+
+        @Override
+        public boolean canHandle(HttpServletRequest request) {
+
+            return false;
+        }
+
+        @Override
+        public String getContextIdentifier(HttpServletRequest request) {
+
+            return "";
+        }
+
+        @Override
+        public String getName() {
+
+            return "TestOTPAuthenticator";
+        }
+
+        @Override
+        public String getFriendlyName() {
+
+            return "Test OTP Authenticator";
+        }
+    }
+}
+

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
@@ -208,8 +208,8 @@ public class ContextBasedOTPControlTest {
         AuthenticationContext context = createContextWithRuntimeParams(
                 SKIP_RESEND_BLOCK_TIME, "false");
 
-        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == false
-        // => return !false => true
+        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == false, but the underlying
+        // AbstractOTPAuthenticator.isUserBasedOTPResendBlockingEnabled() returns false by default in this setup.
         Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
     }
 
@@ -628,8 +628,8 @@ public class ContextBasedOTPControlTest {
         context.setTenantDomain(TENANT_DOMAIN);
         int remaining = invokePrivateIntMethod(
                 "getRemainingNumberOfContextBasedRetryAttempts",
-                new Class[]{String.class, AuthenticationContext.class},
-                new Object[]{TENANT_DOMAIN, context});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         Assert.assertEquals(remaining, 3);
     }
 
@@ -643,8 +643,8 @@ public class ContextBasedOTPControlTest {
         context.setTenantDomain(TENANT_DOMAIN);
         int remaining = invokePrivateIntMethod(
                 "getRemainingNumberOfContextBasedRetryAttempts",
-                new Class[]{String.class, AuthenticationContext.class},
-                new Object[]{TENANT_DOMAIN, context});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         Assert.assertEquals(remaining, 0);
     }
 
@@ -658,8 +658,8 @@ public class ContextBasedOTPControlTest {
         context.setTenantDomain(TENANT_DOMAIN);
         int remaining = invokePrivateIntMethod(
                 "getRemainingNumberOfContextBasedRetryAttempts",
-                new Class[]{String.class, AuthenticationContext.class},
-                new Object[]{TENANT_DOMAIN, context});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         Assert.assertEquals(remaining, 0);
     }
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
@@ -44,7 +44,6 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_ALLOWED_FAILURE_LIMIT;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_RESEND_LIMIT;
-import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SKIP_RESEND_BLOCK_TIME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED;
 
 /**
@@ -187,40 +186,6 @@ public class ContextBasedOTPControlTest {
 
         AuthenticationContext context = createContextWithRuntimeParams(null, null);
         Assert.assertFalse(authenticator.isTerminateOnResendLimitExceeded(context));
-    }
-
-    @Test(description = "User-based resend blocking is disabled when skipResendBlockTime runtime param is 'true'")
-    public void testIsUserBasedOTPResendBlockingEnabled_SkipResendBlockTimeTrue()
-            throws AuthenticationFailedException {
-
-        AuthenticationContext context = createContextWithRuntimeParams(
-                SKIP_RESEND_BLOCK_TIME, "true");
-
-        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == true
-        // => return !true => false
-        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
-    }
-
-    @Test(description = "User-based resend blocking is enabled when skipResendBlockTime runtime param is 'false'")
-    public void testIsUserBasedOTPResendBlockingEnabled_SkipResendBlockTimeFalse()
-            throws AuthenticationFailedException {
-
-        AuthenticationContext context = createContextWithRuntimeParams(
-                SKIP_RESEND_BLOCK_TIME, "false");
-
-        // skipResendBlockTimeParam.isPresent() && skipResendBlockTimeParam.get() == false, but the underlying
-        // AbstractOTPAuthenticator.isUserBasedOTPResendBlockingEnabled() returns false by default in this setup.
-        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
-    }
-
-    @Test(description = "User-based resend blocking falls back to default (false) when skipResendBlockTime is absent")
-    public void testIsUserBasedOTPResendBlockingEnabled_NoOverride()
-            throws AuthenticationFailedException {
-
-        AuthenticationContext context = createContextWithRuntimeParams(null, null);
-
-        // No override → falls back to isUserBasedOTPResendBlockingEnabled() which returns false by default
-        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
     }
 
     @Test(description = "updateContextOTPResendCount initialises the counter to 1 when not set")
@@ -682,11 +647,10 @@ public class ContextBasedOTPControlTest {
     public void testSkipResendBlockTimeOverridesUserBasedBlocking() throws AuthenticationFailedException {
 
         Map<String, String> params = new HashMap<>();
-        params.put(SKIP_RESEND_BLOCK_TIME, "true");
         params.put(MAXIMUM_RESEND_LIMIT, "3");
         AuthenticationContext context = createContextWithMultipleRuntimeParams(params);
         // User-based blocking is skipped
-        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled(context));
+        Assert.assertFalse(authenticator.isUserBasedOTPResendBlockingEnabled());
         // Context-based blocking is still enabled independently
         Assert.assertTrue(authenticator.isContextBasedOTPResendBlockingEnabled(context));
     }

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtilsTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtilsTest.java
@@ -63,334 +63,223 @@ public class AuthenticatorUtilsTest {
         }
     }
 
-    @Test(description = "Returns the value when the param exists in the map")
-    public void testGetOptionalParam_WhenParamExists() {
+    @DataProvider(name = "getStringRuntimeParamByNameData")
+    public Object[][] getStringRuntimeParamByNameData() {
 
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "hello");
+        Map<String, String> presentParam = new HashMap<>();
+        presentParam.put(PARAM_NAME, "hello");
 
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+        Map<String, String> otherParam = new HashMap<>();
+        otherParam.put("otherParam", "value");
 
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(result.get(), "hello");
+        Map<String, String> blankValue = new HashMap<>();
+        blankValue.put(PARAM_NAME, "");
+
+        Map<String, String> nullValue = new HashMap<>();
+        nullValue.put(PARAM_NAME, null);
+
+        return new Object[][] {
+                {"Returns the value when the param exists in the map",
+                        presentParam, true, "hello"},
+                {"Returns empty when the param key is absent from the map",
+                        otherParam, false, null},
+                {"Returns empty when the runtime params map is null",
+                        null, false, null},
+                {"Returns empty when the runtime params map is empty",
+                        Collections.emptyMap(), false, null},
+                {"Returns empty when the param value is a blank string",
+                        blankValue, false, null},
+                {"Returns empty when the param value stored in the map is null",
+                        nullValue, false, null},
+        };
     }
 
-    @Test(description = "Returns empty when the param key is absent from the map")
-    public void testGetOptionalParam_WhenParamAbsent() {
+    @Test(dataProvider = "getStringRuntimeParamByNameData",
+            description = "getStringRuntimeParamByName returns expected Optional for various inputs")
+    public void testGetStringRuntimeParamByName(String scenario, Map<String, String> params,
+                                                boolean expectPresent, String expectedValue) {
 
-        Map<String, String> params = new HashMap<>();
-        params.put("otherParam", "value");
-
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
+        Optional<String> result = AuthenticatorUtils.getStringRuntimeParamByName(params, PARAM_NAME);
+        Assert.assertEquals(result.isPresent(), expectPresent, scenario);
+        if (expectPresent) {
+            Assert.assertEquals(result.get(), expectedValue, scenario);
+        }
     }
 
-    @Test(description = "Returns empty when the runtime params map is null")
-    public void testGetOptionalParam_WhenMapIsNull() {
+    @DataProvider(name = "getBooleanRuntimeParamByNameData")
+    public Object[][] getBooleanRuntimeParamByNameData() {
 
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(null, PARAM_NAME);
+        Map<String, String> trueParam = new HashMap<>();
+        trueParam.put(PARAM_NAME, "true");
 
-        Assert.assertFalse(result.isPresent());
+        Map<String, String> falseParam = new HashMap<>();
+        falseParam.put(PARAM_NAME, "false");
+
+        Map<String, String> upperCaseTrueParam = new HashMap<>();
+        upperCaseTrueParam.put(PARAM_NAME, "TRUE");
+
+        Map<String, String> nonBooleanParam = new HashMap<>();
+        nonBooleanParam.put(PARAM_NAME, "yes");
+
+        Map<String, String> otherParam = new HashMap<>();
+        otherParam.put("otherParam", "true");
+
+        return new Object[][] {
+                {"Returns Optional.of(true) when the param value is 'true'",
+                        trueParam, true, Boolean.TRUE},
+                {"Returns Optional.of(false) when the param value is 'false'",
+                        falseParam, true, Boolean.FALSE},
+                {"Returns Optional.of(true) for 'TRUE' (case-insensitive)",
+                        upperCaseTrueParam, true, Boolean.TRUE},
+                {"Returns Optional.of(false) when the param value is a non-boolean string",
+                        nonBooleanParam, true, Boolean.FALSE},
+                {"Returns empty when the runtime params map is null",
+                        null, false, null},
+                {"Returns empty when the runtime params map is empty",
+                        Collections.emptyMap(), false, null},
+                {"Returns empty when the param key is absent",
+                        otherParam, false, null},
+        };
     }
 
-    @Test(description = "Returns empty when the runtime params map is empty")
-    public void testGetOptionalParam_WhenMapIsEmpty() {
+    @Test(dataProvider = "getBooleanRuntimeParamByNameData",
+            description = "getBooleanRuntimeParamByName returns expected Optional for various inputs")
+    public void testGetBooleanRuntimeParamByName(String scenario, Map<String, String> params,
+                                                 boolean expectPresent, Boolean expectedValue) {
 
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(
-                Collections.emptyMap(), PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
+        Optional<Boolean> result = AuthenticatorUtils.getBooleanRuntimeParamByName(params, PARAM_NAME);
+        Assert.assertEquals(result.isPresent(), expectPresent, scenario);
+        if (expectPresent) {
+            Assert.assertEquals(result.get(), expectedValue, scenario);
+        }
     }
 
-    @Test(description = "Returns the value when it is a blank string (blank is a valid value)")
-    public void testGetOptionalParam_WhenValueIsBlankString() {
+    @DataProvider(name = "getIntRuntimeParamByNameData")
+    public Object[][] getIntRuntimeParamByNameData() {
 
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "");
+        Map<String, String> validIntParam = new HashMap<>();
+        validIntParam.put(PARAM_NAME, "42");
 
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+        Map<String, String> zeroParam = new HashMap<>();
+        zeroParam.put(PARAM_NAME, "0");
 
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(result.get(), "");
+        Map<String, String> negativeParam = new HashMap<>();
+        negativeParam.put(PARAM_NAME, "-5");
+
+        Map<String, String> nonNumericParam = new HashMap<>();
+        nonNumericParam.put(PARAM_NAME, "notAnInt");
+
+        Map<String, String> decimalParam = new HashMap<>();
+        decimalParam.put(PARAM_NAME, "3.14");
+
+        Map<String, String> nullValueParam = new HashMap<>();
+        nullValueParam.put(PARAM_NAME, null);
+
+        Map<String, String> otherParam = new HashMap<>();
+        otherParam.put("otherParam", "10");
+
+        return new Object[][] {
+                {"Returns the parsed integer when the param value is a valid integer string",
+                        validIntParam, true, 42},
+                {"Returns the parsed integer for a zero value",
+                        zeroParam, true, 0},
+                {"Returns the parsed integer for a negative value",
+                        negativeParam, true, -5},
+                {"Returns empty for a non-numeric value",
+                        nonNumericParam, false, 0},
+                {"Returns empty for a decimal string value",
+                        decimalParam, false, 0},
+                {"Returns empty when the runtime params map is null",
+                        null, false, 0},
+                {"Returns empty when the runtime params map is empty",
+                        Collections.emptyMap(), false, 0},
+                {"Returns empty when the param key is absent from the map",
+                        otherParam, false, 0},
+                {"Returns empty when the param value stored in the map is null",
+                        nullValueParam, false, 0},
+        };
     }
 
-    @Test(description = "Returns empty when the param value stored in the map is null")
-    public void testGetOptionalParam_WhenValueIsNull() {
+    @Test(dataProvider = "getIntRuntimeParamByNameData",
+            description = "getIntRuntimeParamByName returns expected OptionalInt for various inputs")
+    public void testGetIntRuntimeParamByName(String scenario, Map<String, String> params,
+                                             boolean expectPresent, int expectedValue) {
 
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, null);
-
-        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns Optional.of(true) when the param value is 'true'")
-    public void testGetOptionalBooleanParam_WhenValueIsTrue() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "true");
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertTrue(result.get());
-    }
-
-    @Test(description = "Returns Optional.of(false) when the param value is 'false'")
-    public void testGetOptionalBooleanParam_WhenValueIsFalse() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "false");
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertFalse(result.get());
-    }
-
-    @Test(description = "Returns Optional.of(true) for 'TRUE' (case-insensitive)")
-    public void testGetOptionalBooleanParam_WhenValueIsTrueUpperCase() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "TRUE");
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertTrue(result.get());
-    }
-
-    @Test(description = "Returns Optional.of(false) when the param value is a non-boolean string")
-    public void testGetOptionalBooleanParam_WhenValueIsNonBoolean() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "yes");
-
-        // Boolean.parseBoolean("yes") → false
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertFalse(result.get());
-    }
-
-    @Test(description = "Returns empty when the runtime params map is null")
-    public void testGetOptionalBooleanParam_WhenMapIsNull() {
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(null, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the runtime params map is empty")
-    public void testGetOptionalBooleanParam_WhenMapIsEmpty() {
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(
-                        Collections.emptyMap(), PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the param key is absent")
-    public void testGetOptionalBooleanParam_WhenParamAbsent() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put("otherParam", "true");
-
-        Optional<Boolean> result =
-                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns the parsed integer when the param value is a valid integer string")
-    public void testGetOptionalIntParam_WhenValueIsValidInt() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "42");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(result.getAsInt(), 42);
-    }
-
-    @Test(description = "Returns the parsed integer for a zero value")
-    public void testGetOptionalIntParam_WhenValueIsZero() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "0");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(result.getAsInt(), 0);
-    }
-
-    @Test(description = "Returns the parsed integer for a negative value")
-    public void testGetOptionalIntParam_WhenValueIsNegative() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "-5");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(result.getAsInt(), -5);
-    }
-
-    @Test(description = "Returns empty and does NOT throw when the param value is non-numeric")
-    public void testGetOptionalIntParam_WhenValueIsNonNumeric() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "notAnInt");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty and does NOT throw when the param value is a decimal string")
-    public void testGetOptionalIntParam_WhenValueIsDecimal() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, "3.14");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the runtime params map is null")
-    public void testGetOptionalIntParam_WhenMapIsNull() {
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(null, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the runtime params map is empty")
-    public void testGetOptionalIntParam_WhenMapIsEmpty() {
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
-                Collections.emptyMap(), PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the param key is absent from the map")
-    public void testGetOptionalIntParam_WhenParamAbsent() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put("otherParam", "10");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
-    }
-
-    @Test(description = "Returns empty when the param value stored in the map is null")
-    public void testGetOptionalIntParam_WhenValueIsNull() {
-
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, null);
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
-        Assert.assertFalse(result.isPresent());
+        OptionalInt result = AuthenticatorUtils.getIntRuntimeParamByName(params, PARAM_NAME);
+        Assert.assertEquals(result.isPresent(), expectPresent, scenario);
+        if (expectPresent) {
+            Assert.assertEquals(result.getAsInt(), expectedValue, scenario);
+        }
     }
 
     @Test(description = "Triggers a diagnostic log event for non-numeric values when diagnostic logging is enabled")
-    public void testGetOptionalIntParam_NonNumeric_TriggersDiagnosticLog_WhenEnabled() {
+    public void testGetIntRuntimeParamByNameNonNumericTriggersDiagnosticLogWhenEnabled() {
 
         loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
         loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
-
         Map<String, String> params = new HashMap<>();
         params.put(PARAM_NAME, "bad_value");
-
-        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
+        OptionalInt result = AuthenticatorUtils.getIntRuntimeParamByName(params, PARAM_NAME);
         Assert.assertFalse(result.isPresent());
         loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), times(1));
     }
 
     @Test(description = "Does NOT trigger a diagnostic log event for non-numeric values when diagnostic logging is disabled")
-    public void testGetOptionalIntParam_NonNumeric_NoDiagnosticLog_WhenDisabled() {
+    public void testGetIntRuntimeParamByNameNonNumericNoDiagnosticLogWhenDisabled() {
 
         // isDiagnosticLogsEnabled already returns false from setUp().
         Map<String, String> params = new HashMap<>();
         params.put(PARAM_NAME, "bad_value");
-
-        AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
-
+        AuthenticatorUtils.getIntRuntimeParamByName(params, PARAM_NAME);
         loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), never());
     }
 
-    // =========================================================================
-    // logDiagnostic
-    // =========================================================================
+    @DataProvider(name = "triggerDiagnosticLogData")
+    public Object[][] triggerDiagnosticLogData() {
 
-    @Test(description = "triggerDiagnosticLogEvent is called when diagnostic logging is enabled")
-    public void testLogDiagnostic_WhenEnabled_CallsTrigger() {
+        return new Object[][] {
+                {"triggerDiagnosticLogEvent is called when diagnostic logging is enabled",
+                        true, DiagnosticLog.ResultStatus.SUCCESS, 1},
+                {"triggerDiagnosticLogEvent is NOT called when diagnostic logging is disabled",
+                        false, DiagnosticLog.ResultStatus.FAILED, 0},
+        };
+    }
 
-        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+    @Test(dataProvider = "triggerDiagnosticLogData",
+            description = "triggerDiagnosticLog conditionally calls triggerDiagnosticLogEvent based on logging status")
+    public void testTriggerDiagnosticLog(String scenario, boolean loggingEnabled,
+                                         DiagnosticLog.ResultStatus status, int expectedInvocations) {
+
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(loggingEnabled);
         loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
-
-        AuthenticatorUtils.logDiagnostic(
+        AuthenticatorUtils.triggerDiagnosticLog(
                 "componentId",
                 "actionId",
                 "test message",
-                DiagnosticLog.ResultStatus.SUCCESS,
+                status,
                 DiagnosticLog.LogDetailLevel.APPLICATION);
-
-        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), times(1));
+        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), times(expectedInvocations));
     }
 
-    @Test(description = "triggerDiagnosticLogEvent is NOT called when diagnostic logging is disabled")
-    public void testLogDiagnostic_WhenDisabled_DoesNotCallTrigger() {
-
-        // isDiagnosticLogsEnabled returns false from setUp().
-        AuthenticatorUtils.logDiagnostic(
-                "componentId",
-                "actionId",
-                "test message",
-                DiagnosticLog.ResultStatus.FAILED,
-                DiagnosticLog.LogDetailLevel.APPLICATION);
-
-        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), never());
-    }
-
-    @Test(description = "logDiagnostic does not throw for any ResultStatus value")
-    public void testLogDiagnostic_AllResultStatuses_NoException() {
+    @Test(description = "triggerDiagnosticLog does not throw for any ResultStatus value")
+    public void testTriggerDiagnosticLogAllResultStatusesNoException() {
 
         loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
         loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
-
-        // Should not throw for any status value.
         for (DiagnosticLog.ResultStatus status : DiagnosticLog.ResultStatus.values()) {
-            AuthenticatorUtils.logDiagnostic("c", "a", "msg", status,
+            AuthenticatorUtils.triggerDiagnosticLog("c", "a", "msg", status,
                     DiagnosticLog.LogDetailLevel.APPLICATION);
         }
     }
 
-    @Test(description = "logDiagnostic does not throw for any LogDetailLevel value")
-    public void testLogDiagnostic_AllLogDetailLevels_NoException() {
+    @Test(description = "triggerDiagnosticLog does not throw for any LogDetailLevel value")
+    public void testTriggerDiagnosticLogAllLogDetailLevelsNoException() {
 
         loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
         loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
-
         for (DiagnosticLog.LogDetailLevel level : DiagnosticLog.LogDetailLevel.values()) {
-            AuthenticatorUtils.logDiagnostic("c", "a", "msg",
+            AuthenticatorUtils.triggerDiagnosticLog("c", "a", "msg",
                     DiagnosticLog.ResultStatus.SUCCESS, level);
         }
     }
 }
-

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtilsTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/util/AuthenticatorUtilsTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.otp.core.util;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.utils.DiagnosticLog;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+/**
+ * Unit tests for AuthenticatorUtils.
+ */
+public class AuthenticatorUtilsTest {
+
+    private static final String PARAM_NAME = "testParam";
+
+    private MockedStatic<LoggerUtils> loggerUtilsMock;
+
+    @BeforeMethod
+    public void setUp() {
+
+        loggerUtilsMock = mockStatic(LoggerUtils.class);
+        // Disable diagnostic logging by default; individual tests override this where needed.
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (loggerUtilsMock != null) {
+            loggerUtilsMock.close();
+        }
+    }
+
+    @Test(description = "Returns the value when the param exists in the map")
+    public void testGetOptionalParam_WhenParamExists() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "hello");
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), "hello");
+    }
+
+    @Test(description = "Returns empty when the param key is absent from the map")
+    public void testGetOptionalParam_WhenParamAbsent() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put("otherParam", "value");
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is null")
+    public void testGetOptionalParam_WhenMapIsNull() {
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(null, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is empty")
+    public void testGetOptionalParam_WhenMapIsEmpty() {
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(
+                Collections.emptyMap(), PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns the value when it is a blank string (blank is a valid value)")
+    public void testGetOptionalParam_WhenValueIsBlankString() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "");
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), "");
+    }
+
+    @Test(description = "Returns empty when the param value stored in the map is null")
+    public void testGetOptionalParam_WhenValueIsNull() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, null);
+
+        Optional<String> result = AuthenticatorUtils.getOptionalParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns Optional.of(true) when the param value is 'true'")
+    public void testGetOptionalBooleanParam_WhenValueIsTrue() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "true");
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertTrue(result.get());
+    }
+
+    @Test(description = "Returns Optional.of(false) when the param value is 'false'")
+    public void testGetOptionalBooleanParam_WhenValueIsFalse() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "false");
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertFalse(result.get());
+    }
+
+    @Test(description = "Returns Optional.of(true) for 'TRUE' (case-insensitive)")
+    public void testGetOptionalBooleanParam_WhenValueIsTrueUpperCase() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "TRUE");
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertTrue(result.get());
+    }
+
+    @Test(description = "Returns Optional.of(false) when the param value is a non-boolean string")
+    public void testGetOptionalBooleanParam_WhenValueIsNonBoolean() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "yes");
+
+        // Boolean.parseBoolean("yes") → false
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertFalse(result.get());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is null")
+    public void testGetOptionalBooleanParam_WhenMapIsNull() {
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(null, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is empty")
+    public void testGetOptionalBooleanParam_WhenMapIsEmpty() {
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(
+                        Collections.emptyMap(), PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the param key is absent")
+    public void testGetOptionalBooleanParam_WhenParamAbsent() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put("otherParam", "true");
+
+        Optional<Boolean> result =
+                AuthenticatorUtils.getOptionalBooleanParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns the parsed integer when the param value is a valid integer string")
+    public void testGetOptionalIntParam_WhenValueIsValidInt() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "42");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.getAsInt(), 42);
+    }
+
+    @Test(description = "Returns the parsed integer for a zero value")
+    public void testGetOptionalIntParam_WhenValueIsZero() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "0");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.getAsInt(), 0);
+    }
+
+    @Test(description = "Returns the parsed integer for a negative value")
+    public void testGetOptionalIntParam_WhenValueIsNegative() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "-5");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.getAsInt(), -5);
+    }
+
+    @Test(description = "Returns empty and does NOT throw when the param value is non-numeric")
+    public void testGetOptionalIntParam_WhenValueIsNonNumeric() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "notAnInt");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty and does NOT throw when the param value is a decimal string")
+    public void testGetOptionalIntParam_WhenValueIsDecimal() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "3.14");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is null")
+    public void testGetOptionalIntParam_WhenMapIsNull() {
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(null, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the runtime params map is empty")
+    public void testGetOptionalIntParam_WhenMapIsEmpty() {
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(
+                Collections.emptyMap(), PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the param key is absent from the map")
+    public void testGetOptionalIntParam_WhenParamAbsent() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put("otherParam", "10");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Returns empty when the param value stored in the map is null")
+    public void testGetOptionalIntParam_WhenValueIsNull() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, null);
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test(description = "Triggers a diagnostic log event for non-numeric values when diagnostic logging is enabled")
+    public void testGetOptionalIntParam_NonNumeric_TriggersDiagnosticLog_WhenEnabled() {
+
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+        loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "bad_value");
+
+        OptionalInt result = AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        Assert.assertFalse(result.isPresent());
+        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), times(1));
+    }
+
+    @Test(description = "Does NOT trigger a diagnostic log event for non-numeric values when diagnostic logging is disabled")
+    public void testGetOptionalIntParam_NonNumeric_NoDiagnosticLog_WhenDisabled() {
+
+        // isDiagnosticLogsEnabled already returns false from setUp().
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, "bad_value");
+
+        AuthenticatorUtils.getOptionalIntParamFromRuntimeParams(params, PARAM_NAME);
+
+        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), never());
+    }
+
+    // =========================================================================
+    // logDiagnostic
+    // =========================================================================
+
+    @Test(description = "triggerDiagnosticLogEvent is called when diagnostic logging is enabled")
+    public void testLogDiagnostic_WhenEnabled_CallsTrigger() {
+
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+        loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
+
+        AuthenticatorUtils.logDiagnostic(
+                "componentId",
+                "actionId",
+                "test message",
+                DiagnosticLog.ResultStatus.SUCCESS,
+                DiagnosticLog.LogDetailLevel.APPLICATION);
+
+        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), times(1));
+    }
+
+    @Test(description = "triggerDiagnosticLogEvent is NOT called when diagnostic logging is disabled")
+    public void testLogDiagnostic_WhenDisabled_DoesNotCallTrigger() {
+
+        // isDiagnosticLogsEnabled returns false from setUp().
+        AuthenticatorUtils.logDiagnostic(
+                "componentId",
+                "actionId",
+                "test message",
+                DiagnosticLog.ResultStatus.FAILED,
+                DiagnosticLog.LogDetailLevel.APPLICATION);
+
+        loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any()), never());
+    }
+
+    @Test(description = "logDiagnostic does not throw for any ResultStatus value")
+    public void testLogDiagnostic_AllResultStatuses_NoException() {
+
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+        loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
+
+        // Should not throw for any status value.
+        for (DiagnosticLog.ResultStatus status : DiagnosticLog.ResultStatus.values()) {
+            AuthenticatorUtils.logDiagnostic("c", "a", "msg", status,
+                    DiagnosticLog.LogDetailLevel.APPLICATION);
+        }
+    }
+
+    @Test(description = "logDiagnostic does not throw for any LogDetailLevel value")
+    public void testLogDiagnostic_AllLogDetailLevels_NoException() {
+
+        loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+        loggerUtilsMock.when(() -> LoggerUtils.triggerDiagnosticLogEvent(any())).thenAnswer(inv -> null);
+
+        for (DiagnosticLog.LogDetailLevel level : DiagnosticLog.LogDetailLevel.values()) {
+            AuthenticatorUtils.logDiagnostic("c", "a", "msg",
+                    DiagnosticLog.ResultStatus.SUCCESS, level);
+        }
+    }
+}
+

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/resources/testng.xml
@@ -23,6 +23,9 @@
         <classes>
             <class name="org.wso2.carbon.identity.auth.otp.core.AbstractOTPExecutorTest"/>
             <class name="org.wso2.carbon.identity.auth.otp.core.AbstractOTPAuthenticatorTest"/>
+            <class name="org.wso2.carbon.identity.auth.otp.core.AbstractOTPAuthenticatorFlowTest"/>
+            <class name="org.wso2.carbon.identity.auth.otp.core.ContextBasedOTPControlTest"/>
+            <class name="org.wso2.carbon.identity.auth.otp.core.util.AuthenticatorUtilsTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.558</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.35</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
 
         <commons.logging.version>1.2</commons.logging.version>
         <commons-logging.osgi.version.range>[1.2.0,2.0.0)</commons-logging.osgi.version.range>
+        <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <imp.pkg.version.javax.servlet>[3.1.0, 4.0.0)</imp.pkg.version.javax.servlet>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/26743

This pull request introduces significant enhancements and refactoring to the OTP authentication flow in `AbstractOTPAuthenticator.java`. The changes add context-based blocking and retry limits for OTP resends and submissions, making the authentication process more configurable and robust. The update also improves how limits are enforced and error handling is managed when those limits are exceeded.

**Enhancements to OTP resend and retry limits:**

* Added context-based blocking for OTP resend and retry attempts, allowing configuration of maximum allowed attempts per authentication context and enabling both user-based and context-based blocking. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R197-R249) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L321-R382) [[3]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L362-L371) [[4]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L414-R489)
* Introduced methods for updating and resetting context-level counters for OTP resend and retry attempts, and for retrieving current retry attempts. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L1088-R1266) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R1276-R1322)

**Error handling improvements:**

* Enhanced handling of scenarios where resend or retry limits are exceeded, including options to terminate the authentication flow or redirect to an error page based on configuration. Added new error codes for these scenarios.
* Improved logic for handling OTP resend attempts within block windows, ensuring correct user feedback and flow control.

**Configuration and utility updates:**

* Added new constants and imports to support expanded error codes and configuration options for context-based limits. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R39) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R119-R121) [[3]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R133-R138)
* Updated logic for determining maximum allowed resend and retry attempts, factoring in both user and context configurations. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L340-R400) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L1088-R1266)

**Authentication flow robustness:**

* Ensured that context-level counters are reset after successful authentication, preventing carry-over between sessions.
* Added logic to increment retry counters and enforce retry blocking during OTP verification, improving security and user experience.