### PR TITLE
Handle number format exception scenario.

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -667,7 +667,15 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         int allowedResendAttemptsCount = getMaximumResendAttempts(applicationTenantDomain, context);
-        int currentResendAttempt = getCurrentResendAttempt(context);
+        int currentResendAttempt;
+        try {
+            currentResendAttempt = getCurrentResendAttempt(context);
+        } catch (NumberFormatException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while parsing the current resend attempt count from context", e);
+            }
+            return true;
+        }
         return currentResendAttempt >= allowedResendAttemptsCount;
     }
 
@@ -686,7 +694,16 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             // Update Context based retry counter only if context based retry blocking is enabled.
             updateContextOTPRetryCount(context);
             int maxRetryAttempts = getMaximumRetryAttempts(applicationTenantDomain, context);
-            int currentRetryAttempts = getCurrentRetryAttempt(context);
+            int currentRetryAttempts;
+            try {
+                currentRetryAttempts = getCurrentRetryAttempt(context);
+            } catch (NumberFormatException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error while parsing the current retry attempt count from context", e);
+                }
+                handleOTPRetryCountExceededScenario(context);
+                return;
+            }
             if (currentRetryAttempts >= maxRetryAttempts) {
                 handleOTPRetryCountExceededScenario(context);
             }
@@ -1189,7 +1206,13 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
             throws AuthenticationFailedException {
 
         int maxRetryAttempts = getMaximumRetryAttempts(context.getTenantDomain(), context);
-        int currentRetryAttempts = getCurrentRetryAttempt(context);
+        int currentRetryAttempts;
+        try {
+            currentRetryAttempts = getCurrentRetryAttempt(context);
+        } catch (NumberFormatException e) {
+            throw new AuthenticationFailedException(
+                    "Error while parsing the current retry attempt count from context", e);
+        }
         int remainingRetryAttempts = maxRetryAttempts - currentRetryAttempts;
         // If the remaining retry attempts is less than 0, then return 0.
         return Math.max(remainingRetryAttempts, 0);
@@ -1436,7 +1459,18 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 StringUtils.isBlank(context.getProperty(key).toString())) {
             context.setProperty(key, 1);
         } else {
-            context.setProperty(key, (int) context.getProperty(key) + 1);
+            int currentCount;
+            try {
+                currentCount = Integer.parseInt(context.getProperty(key).toString());
+            } catch (NumberFormatException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Error while parsing the current count for context property: %s. " +
+                            "Leaving the value as-is so downstream readers treat the counter as exceeded.",
+                            key), e);
+                }
+                return;
+            }
+            context.setProperty(key, currentCount + 1);
         }
     }
 

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/ContextBasedOTPControlTest.java
@@ -23,6 +23,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -626,6 +627,77 @@ public class ContextBasedOTPControlTest {
                 new Class[]{AuthenticationContext.class},
                 new Object[]{context});
         Assert.assertEquals(remaining, 0);
+    }
+
+    @Test(description = "updateContextOTPRetryCount preserves a non-numeric counter value (does NOT reset to 1)")
+    public void testUpdateContextOTPRetryCount_PropertyIsGarbage_PreservesValue() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        authenticator.updateContextOTPRetryCount(context);
+        // Corrupt counter must be preserved so downstream readers fail closed.
+        // Resetting it to 1 would be a security regression (free retry reset on poisoned values).
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), "garbage");
+    }
+
+    @Test(description = "updateContextOTPRetryCount increments a Long-typed counter (parseInt via toString())")
+    public void testUpdateContextOTPRetryCount_PropertyIsLong_Increments() {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, Long.valueOf(4L));
+        authenticator.updateContextOTPRetryCount(context);
+        Assert.assertEquals(context.getProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 5);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt treats a non-numeric retry-count as limit-exceeded")
+    public void testHandleInvalidOTPLoginAttempt_RetryCountCorrupt_TreatsAsLimitExceeded() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        invokePrivateVoidMethod(
+                "handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+        Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+        Assert.assertEquals(
+                context.getProperty(AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR), true);
+    }
+
+    @Test(description = "isOTPResendLimitExceeded returns true when the resend-count property is non-numeric")
+    public void testIsOTPResendLimitExceeded_ResendCountCorrupt_ReturnsTrue() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(MAXIMUM_RESEND_LIMIT, "3");
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        boolean result = invokePrivateBooleanMethod(
+                "isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class, String.class},
+                new Object[]{context, TENANT_DOMAIN});
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "getRemainingNumberOfContextBasedRetryAttempts throws AFE (cause=NFE) on corrupt retry-count")
+    public void testGetRemainingNumberOfContextBasedRetryAttempts_RetryCountCorrupt_ThrowsAFE() throws Exception {
+
+        AuthenticationContext context = createContextWithRuntimeParams(
+                MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        context.setProperty(DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        context.setTenantDomain(TENANT_DOMAIN);
+        try {
+            invokePrivateIntMethod(
+                    "getRemainingNumberOfContextBasedRetryAttempts",
+                    new Class[]{AuthenticationContext.class},
+                    new Object[]{context});
+            Assert.fail("Expected AuthenticationFailedException was not thrown");
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue(cause instanceof AuthenticationFailedException,
+                    "Expected AuthenticationFailedException but got: " + cause.getClass().getName());
+            Assert.assertTrue(cause.getCause() instanceof NumberFormatException,
+                    "Expected NumberFormatException as cause but got: "
+                            + (cause.getCause() == null ? "null" : cause.getCause().getClass().getName()));
+        }
     }
 
     @Test(description = "Both resend and retry limits can be set simultaneously in runtime params")


### PR DESCRIPTION
This pr fixes related scenarios in:

- [ ] https://github.com/wso2-extensions/identity-local-auth-emailotp/pull/80

This pull request improves the robustness and security of OTP retry and resend attempt handling by making the code more resilient to corrupt or non-numeric counter values in the authentication context. It updates the logic to fail safely and consistently in the presence of such values, ensuring that security is not compromised. Comprehensive unit tests are added to verify these behaviors.

**Error handling and resilience improvements:**

* Updated `isOTPResendLimitExceeded`, `handleInvalidOTPLoginAttempt`, `getRemainingNumberOfContextBasedRetryAttempts`, and `incrementContextCounter` in `AbstractOTPAuthenticator.java` to gracefully handle non-numeric or corrupt counter values by either treating them as limit-exceeded, preserving the value, or throwing an `AuthenticationFailedException` as appropriate. This prevents potential security loopholes from counter resets or bypasses. [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L670-R678) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L689-R706) [[3]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L1192-R1215) [[4]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L1439-R1473)

**Testing enhancements:**

* Added new unit tests in `ContextBasedOTPControlTest.java` to verify correct behavior when counter values are non-numeric or of unexpected types, ensuring the system fails closed and does not reset counters inappropriately. These tests cover incrementing, preserving, and exception-throwing scenarios for corrupted counter properties.
* Added missing import for `AbstractApplicationAuthenticator` to support new test logic.