### PR TITLE
Add extension point to include provider error codes in the OTP page redirect URL

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -138,6 +138,7 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RECAPTCHA_PARAM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RESEND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RETRY_QUERY_PARAMS;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.ERROR_CODE_QUERY_PARAM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SCREEN_VALUE_QUERY_PARAM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.TERMINATE_ON_RESEND_LIMIT_EXCEEDED;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.UNKNOWN_USER;
@@ -1129,6 +1130,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 queryParamsBuilder.append(screenValueQueryParam);
             }
         }
+        boolean retryParamsAdded = false;
         if (context.isRetrying() && !Boolean.parseBoolean(request.getParameter(RESEND))) {
             if (isShowAuthFailureReason()) {
                 String remainingNumberOfOtpAttemptsQueryParam = getRemainingNumberOfOtpAttemptsQueryParam();
@@ -1140,10 +1142,18 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 }
             }
             queryParamsBuilder.append(RETRY_QUERY_PARAMS);
+            retryParamsAdded = true;
         }
         if (isOTPAsFirstFactor(context)) {
             String captchaParams = getCaptchaParams(request, context, tenantDomain, authenticatedUser);
             queryParamsBuilder.append(captchaParams);
+        }
+        String additionalErrorCode = getOTPPageRedirectErrorCode(context);
+        if (StringUtils.isNotBlank(additionalErrorCode)) {
+            if (!retryParamsAdded) {
+                queryParamsBuilder.append(RETRY_QUERY_PARAMS);
+            }
+            queryParamsBuilder.append(ERROR_CODE_QUERY_PARAM).append(additionalErrorCode);
         }
         try {
             String otpLoginPage = getOTPLoginPageURL(context);
@@ -1939,6 +1949,19 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
     protected abstract String getOTPLoginPageURL(AuthenticationContext context) throws AuthenticationFailedException;
 
     protected String getRemainingNumberOfOtpAttemptsQueryParam() {
+
+        return null;
+    }
+
+    /**
+     * Returns an error code to be appended to the OTP login page redirect URL.
+     * If null is returned, no error code is added. When a non-null value is returned and the retry
+     * params have not yet been added to the URL, they will be added automatically.
+     *
+     * @param context Authentication context.
+     * @return Error code string, or null to skip.
+     */
+    protected String getOTPPageRedirectErrorCode(AuthenticationContext context) throws AuthenticationFailedException {
 
         return null;
     }

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -61,6 +61,7 @@ public class AuthenticatorConstants {
     public static final String ERROR_USER_RESEND_COUNT_EXCEEDED_QUERY_PARAMS =
             "&authFailure=true&authFailureMsg=resent.count.exceeded";
     public static final String SCREEN_VALUE_QUERY_PARAM = "&screenValue=";
+    public static final String ERROR_CODE_QUERY_PARAM = "&errorCode=";
     public static final String UNLOCK_QUERY_PARAM = "&unlockTime=";
     public static final String MULTI_OPTION_URI_PARAM = "&multiOptionURI=";
     public static final String RECAPTCHA_PARAM = "&reCaptcha=";

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
@@ -51,11 +51,14 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.CODE;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
@@ -436,6 +439,65 @@ public class AbstractOTPAuthenticatorFlowTest {
         return context;
     }
 
+    @Test(description = "process() with INITIAL_OTP scenario and errorCode set redirects with errorCode in URL")
+    public void testProcess_WithErrorCode_RedirectUrlIncludesErrorCode() throws Exception {
+
+        authenticator.setErrorCodeForRedirect("SP-60001");
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(false);
+        context.setCurrentStep(1);
+
+        authenticator.process(request, response, context);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendRedirect(urlCaptor.capture());
+        String redirectUrl = urlCaptor.getValue();
+        Assert.assertTrue(redirectUrl.contains("errorCode=SP-60001"),
+                "Redirect URL should contain errorCode=SP-60001, but was: " + redirectUrl);
+        Assert.assertTrue(redirectUrl.contains("authFailure=true"),
+                "Redirect URL should contain authFailure=true (added before errorCode), but was: " + redirectUrl);
+    }
+
+    @Test(description = "process() with retrying context and errorCode does not duplicate authFailure param")
+    public void testProcess_Retrying_WithErrorCode_RetryParamsNotDuplicated() throws Exception {
+
+        authenticator.setErrorCodeForRedirect("SP-60001");
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(true);
+        context.setCurrentStep(1);
+
+        authenticator.process(request, response, context);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendRedirect(urlCaptor.capture());
+        String redirectUrl = urlCaptor.getValue();
+        Assert.assertTrue(redirectUrl.contains("errorCode=SP-60001"),
+                "Redirect URL should contain errorCode=SP-60001, but was: " + redirectUrl);
+
+        // authFailure=true should appear exactly once — not duplicated.
+        int firstIndex = redirectUrl.indexOf("authFailure=true");
+        Assert.assertTrue(firstIndex >= 0,
+                "Redirect URL should contain authFailure=true, but was: " + redirectUrl);
+        Assert.assertEquals(redirectUrl.indexOf("authFailure=true", firstIndex + 1), -1,
+                "authFailure=true should appear only once in redirect URL, but was: " + redirectUrl);
+    }
+
     /**
      * Test authenticator that allows configuring canHandle and runtime params for flow tests.
      */
@@ -443,6 +505,7 @@ public class AbstractOTPAuthenticatorFlowTest {
 
         private Map<String, String> runtimeParams = new HashMap<>();
         private boolean canHandle = false;
+        private String errorCodeForRedirect = null;
 
         void setRuntimeParams(Map<String, String> params) {
 
@@ -452,6 +515,17 @@ public class AbstractOTPAuthenticatorFlowTest {
         void setCanHandle(boolean canHandle) {
 
             this.canHandle = canHandle;
+        }
+
+        void setErrorCodeForRedirect(String errorCode) {
+
+            this.errorCodeForRedirect = errorCode;
+        }
+
+        @Override
+        protected String getOTPPageRedirectErrorCode(AuthenticationContext context) {
+
+            return errorCodeForRedirect;
         }
 
         @Override

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -47,6 +47,20 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 public class AbstractOTPAuthenticatorTest {
 
     private static final String ERROR_CODE_PREFIX = "OTP";
+
+    @Test
+    public void testGetOTPPageRedirectErrorCodeDefaultReturnsNull() throws Exception {
+
+        TestOTPAuthenticator otpAuthenticator = new TestOTPAuthenticator();
+        AuthenticationContext context = new AuthenticationContext();
+
+        Method method = AbstractOTPAuthenticator.class
+                .getDeclaredMethod("getOTPPageRedirectErrorCode", AuthenticationContext.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(otpAuthenticator, context);
+        Assert.assertNull(result, "Default getOTPPageRedirectErrorCode() should return null");
+    }
 
     @Test
     public void testResolveUserFromRequest() throws Exception {


### PR DESCRIPTION
## Purpose

This PR adds a protected extension hook, `getOTPPageRedirectErrorCode()`, to `AbstractOTPAuthenticator` that allows concrete OTP authenticator implementations to inject a provider-specific error code into the OTP login page redirect URL. This is the base/commons change that enables provider failure surfacing in SMS OTP and other OTP authenticators built on top of this library.

### Changes

**New `ERROR_CODE_QUERY_PARAM` constant**
Added `&errorCode=` as a named constant in `AuthenticatorConstants` for use in the redirect URL builder.

**New `getOTPPageRedirectErrorCode()` extension hook**
Added a `protected` method in `AbstractOTPAuthenticator` that returns `null` by default. Subclasses can override it to return a non-null error code string, which will be appended to the OTP login page redirect URL as `&errorCode=<code>`.

**Updated OTP page redirect logic**
- Tracks whether retry query params have already been appended via a `retryParamsAdded` flag.
- After existing query params are built, calls `getOTPPageRedirectErrorCode(context)`.
- If a non-null code is returned and retry params have not yet been added, appends them first (ensuring `authFailure=true` is always present), then appends `&errorCode=<code>`.
- If retry params were already added (i.e. the context is retrying), the error code is appended without duplication.

## Related Issue
- https://github.com/wso2/product-is/issues/28017