### PR TITLE
Count otp reinitiation flow as resend flow

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticator.java
@@ -87,6 +87,7 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.COUNT_REINITIATIONS_AS_RESENDS;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.CODE;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.Claims.ACCOUNT_UNLOCK_TIME_CLAIM;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_LENGTH;
@@ -133,6 +134,7 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_ALPHA_NUMERIC_CHAR_SET;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_NUMERIC_CHAR_SET;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.DEFAULT_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RECAPTCHA_PARAM;
@@ -176,6 +178,28 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                 // Resend OTP and Submit OTP processing will be handled from here.
                 return super.process(request, response, context);
         }
+    }
+
+    /**
+     * Implicit reinitiation: silently re-triggers OTP generation with no submitted CODE, no RESEND
+     * flag, not a retry, and an OTP already issued in this context.
+     */
+    private boolean isImplicitOTPReinitiation(HttpServletRequest request, AuthenticationContext context) {
+
+        return !context.isRetrying()
+                && StringUtils.isBlank(request.getParameter(CODE))
+                && !Boolean.parseBoolean(request.getParameter(RESEND))
+                && context.getProperty(SENT_OTP_TOKEN_TIME_PREFIX + getName()) != null;
+    }
+
+    /**
+     * CountReinitiationsAsResends toggle. Defaults to true when unconfigured.
+     */
+    protected boolean isCountReinitiationsAsResendsEnabled(AuthenticationContext context) {
+
+        Optional<Boolean> param = AuthenticatorUtils.getBooleanRuntimeParamByName(getRuntimeParams(context),
+                COUNT_REINITIATIONS_AS_RESENDS);
+        return !param.isPresent() || param.get();
     }
 
     /**
@@ -431,6 +455,14 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
         if (scenario == INITIAL_OTP || scenario == RESEND_OTP) {
             int allowedResendAttemptsCountForUserBeforeBlock = getMaximumResendAttempts(applicationTenantDomain);
             boolean isUserBasedOTPResendBlockingEnabled = isUserBasedOTPResendBlockingEnabled() && isUserExists;
+            /*
+             * Whether this send consumes a resend slot: always for an explicit RESEND_OTP, and for an implicit
+             * reinitiation when the CountReinitiationsAsResends toggle is on. The context resend counter is
+             * incremented before sending (as with RESEND_OTP); the user-store resend claim is persisted only
+             * after a successful send.
+             */
+            boolean countAgainstResendLimit = scenario == RESEND_OTP
+                    || (isImplicitOTPReinitiation(request, context) && isCountReinitiationsAsResendsEnabled(context));
             if (isUserBasedOTPResendBlockingEnabled) {
                 otpResendClaims = getOTPResendClaims();
 
@@ -470,16 +502,23 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
                         }
                     }
                 }
-                if (scenario == RESEND_OTP) {
+                if (countAgainstResendLimit) {
                     otpResendCount++;
                     shouldUpdateUserClaim = true;
                 }
             }
 
-            if (isOTPResendLimitExceededScenario(scenario, isUserBasedOTPResendBlockingEnabled, context)) {
+            /*
+             * Context-counter limit applies when context-based blocking is in effect (user-based off,
+             * or context-based explicitly enabled). Implicit reinitiation folds into RESEND_OTP accounting.
+             */
+            boolean contextResendBlockingApplicable =
+                    !isUserBasedOTPResendBlockingEnabled || isContextBasedOTPResendBlockingEnabled(context);
+            if (countAgainstResendLimit && contextResendBlockingApplicable
+                    && isOTPResendLimitExceeded(context, applicationTenantDomain)) {
                 handleOTPResendCountExceededScenario(request, response, context, authenticatingUser);
                 return;
-            } else if (scenario == RESEND_OTP) {
+            } else if (countAgainstResendLimit) {
                 updateContextOTPResendCount(context);
             }
             OTP otp = generateOTP(applicationTenantDomain);
@@ -491,6 +530,7 @@ public abstract class AbstractOTPAuthenticator extends AbstractApplicationAuthen
              */
             try {
                 sendOtp(mappedLocalUser, otp, isInitialFederationAttempt, request, response, context);
+                context.setProperty(SENT_OTP_TOKEN_TIME_PREFIX + getName(), System.currentTimeMillis());
                 LOG.debug("OTP code was sent successfully.");
             } catch (AuthenticationFailedException exception) {
                 String errorGettingUserClaimErrorCode = getAuthenticatorErrorPrefix() + "-"

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/constant/AuthenticatorConstants.java
@@ -45,6 +45,7 @@ public class AuthenticatorConstants {
     public static final String RESEND = "resendCode";
     public static final String CODE = "OTPcode";
     public static final String OTP_TOKEN = "otpToken";
+    public static final String SENT_OTP_TOKEN_TIME_PREFIX = "sentOtpTokenTime.";
     public static final String OTP = "otp";
     public static final String OTP_RESEND_ATTEMPTS = "otpResendAttempts";
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
@@ -72,6 +73,7 @@ public class AuthenticatorConstants {
     public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
     public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
     public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
+    public static final String COUNT_REINITIATIONS_AS_RESENDS = "CountReinitiationsAsResends";
 
     /**
      * Logging constants for the authenticator.

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorFlowTest.java
@@ -66,6 +66,8 @@ import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConst
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_ALLOWED_FAILURE_LIMIT;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.MAXIMUM_RESEND_LIMIT;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.OTP_TOKEN;
+import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.RESEND;
 import static org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants.USERNAME;
 
@@ -274,6 +276,59 @@ public class AbstractOTPAuthenticatorFlowTest {
         Assert.assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
                 FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
         Assert.assertNotNull(context.getProperty(AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR));
+    }
+
+    @Test(description = "Implicit reinit (no CODE, no RESEND, OTP_TOKEN set, !isRetrying, toggle on) "
+            + "bumps the context resend counter on the context-path")
+    public void testProcess_ImplicitReinit_ContextPath_BumpsResendCount() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_RESEND_LIMIT, "5");
+        runtimeParams.put("CountReinitiationsAsResends", "true");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(false);
+        context.setCurrentStep(1);
+        context.setProperty(SENT_OTP_TOKEN_TIME_PREFIX + authenticator.getName(), System.currentTimeMillis());
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 0);
+
+        Assert.assertEquals(authenticator.process(request, response, context), AuthenticatorFlowStatus.INCOMPLETE);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 1,
+                "Implicit reinit should bump context resend counter when CountReinitiationsAsResends is on");
+    }
+
+    @Test(description = "Implicit reinit with toggle off does NOT bump the resend counter")
+    public void testProcess_ImplicitReinit_ToggleOff_NoBump() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(null);
+        when(request.getParameter(USERNAME)).thenReturn(TEST_USER);
+        doNothing().when(response).sendRedirect(anyString());
+
+        Map<String, String> runtimeParams = new HashMap<>();
+        runtimeParams.put(MAXIMUM_RESEND_LIMIT, "5");
+        runtimeParams.put("CountReinitiationsAsResends", "false");
+        authenticator.setRuntimeParams(runtimeParams);
+
+        AuthenticationContext context = createContextWithAuthenticatedUser(TEST_USER);
+        context.setRetrying(false);
+        context.setCurrentStep(1);
+        context.setProperty(OTP_TOKEN, new OTP("000000", System.currentTimeMillis(), 300_000L));
+        context.setProperty(DEFAULT_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 0);
+
+        authenticator.process(request, response, context);
+        Assert.assertEquals(authenticator.getCurrentResendAttempt(context), 0,
+                "Implicit reinit should NOT bump counter when toggle is off");
     }
 
     @Test(description = "process() with RESEND_OTP and resend limit not exceeded increments resend count in initiate path")

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPAuthenticatorTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.auth.otp.core;
 
 import org.mockito.MockedStatic;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
@@ -31,6 +32,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -128,6 +130,37 @@ public class AbstractOTPAuthenticatorTest {
         }
     }
 
+    @DataProvider
+    public Object[][] countReinitiationsAsResendsDataProvider() {
+
+        return new Object[][]{
+                {null, true},
+                {Collections.emptyMap(), true},
+                {Collections.singletonMap("CountReinitiationsAsResends", "true"), true},
+                {Collections.singletonMap("CountReinitiationsAsResends", "TRUE"), true},
+                {Collections.singletonMap("CountReinitiationsAsResends", "false"), false},
+                {Collections.singletonMap("CountReinitiationsAsResends", "bogus"), false}
+        };
+    }
+
+    @Test(dataProvider = "countReinitiationsAsResendsDataProvider")
+    public void testIsCountReinitiationsAsResendsEnabled(Map<String, String> runtimeParams, boolean expected)
+            throws Exception {
+
+        TestOTPAuthenticator authenticator = new TestOTPAuthenticator() {
+            @Override
+            public Map<String, String> getRuntimeParams(AuthenticationContext context) {
+
+                return runtimeParams;
+            }
+        };
+        Method method = AbstractOTPAuthenticator.class
+                .getDeclaredMethod("isCountReinitiationsAsResendsEnabled", AuthenticationContext.class);
+        method.setAccessible(true);
+        Assert.assertEquals(method.invoke(authenticator, new AuthenticationContext()), expected);
+    }
+
+
     /**
      * Test implementation of {@link AbstractOTPAuthenticator} with stubbed abstract behaviours.
      * Includes a configurable runtime params map to simulate authenticator parameters.
@@ -203,4 +236,5 @@ public class AbstractOTPAuthenticatorTest {
             return "";
         }
     }
+
 }


### PR DESCRIPTION
This pull request introduces a new feature for OTP authentication: the ability to count "implicit reinitiations" (when an OTP is silently regenerated without an explicit resend request) against the OTP resend limit, controlled by a new `CountReinitiationsAsResends` toggle. The default behavior is to count these reinitiations as resends unless explicitly disabled. The PR also adds tests to cover this logic and exposes new constants to support the feature.

**OTP Resend Logic Enhancements**
* Added detection of implicit OTP reinitiations and logic to optionally count them against the resend limit, controlled by the new `CountReinitiationsAsResends` parameter (default: enabled). [[1]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R183-R205) [[2]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0R459-R464) [[3]](diffhunk://#diff-9712131f6a4c46234091f87f3209f6b5c6e146a591b806326e1fd970213fbbc0L473-R520)
* Updated resend counting and blocking logic to include implicit reinitiations when the toggle is enabled, ensuring consistent enforcement of resend limits.
* Set a context property (`SENT_OTP_TOKEN_TIME_PREFIX`) whenever an OTP is sent, to help detect implicit reinitiations.

**Constants and Configuration**
* Introduced `SENT_OTP_TOKEN_TIME_PREFIX` and `COUNT_REINITIATIONS_AS_RESENDS` constants in `AuthenticatorConstants` to support the new logic and configuration. [[1]](diffhunk://#diff-787b98df8923230394be345f0dd1061050be8496746b7bf1dedd23fdc96e4fdfR48) [[2]](diffhunk://#diff-787b98df8923230394be345f0dd1061050be8496746b7bf1dedd23fdc96e4fdfR76)

**Testing**
* Added unit tests to verify that implicit reinitiations correctly bump or do not bump the resend counter depending on the toggle, and to validate the toggle's behavior with various configurations. [[1]](diffhunk://#diff-6c877fdf076fa69bd6de101d1c3c0af211e2d3b9fd61c709db30bd3ff6282229R281-R333) [[2]](diffhunk://#diff-ccd43afa86014ecd1ff8589195bdce018e2b9a20250601aa68a80afaa4ad1899R133-R163)

These changes improve the flexibility and security of OTP resend handling, allowing deployments to choose whether silent OTP re-generations should be treated as resend attempts.

### Related PR
- https://github.com/wso2-extensions/identity-local-auth-emailotp/pull/83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to treat silent OTP reinitializations as resend attempts.
  * OTP resend tracking now records recent sends more accurately during authentication.

* **Bug Fixes**
  * Improved resend-limit enforcement so repeated OTP generation is counted consistently.
  * Reduced cases where OTP flows could bypass resend counters when no explicit resend was requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->