### PR TITLE
Add extension point to surface OTP send failures on the OTP page

### DIFF
--- a/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.otp.core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -63,6 +63,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
@@ -149,6 +153,8 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.flow.execution.engine.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.flow.mgt.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.auth.otp.core.constant.OTPExecutorConstants;
 import org.wso2.carbon.identity.auth.otp.core.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.auth.otp.core.model.OTPSendFailureMessage;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -38,6 +39,7 @@ import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServer
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.mgt.model.MessageDTO;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.security.SecureRandom;
@@ -407,6 +409,13 @@ public abstract class AbstractOTPExecutor extends AuthenticationExecutor {
         } catch (IdentityEventException e) {
             logDiagnostic("Error occurred while sending the OTP in " + getName(),
                     DiagnosticLog.ResultStatus.FAILED, SEND_OTP);
+            Optional<OTPSendFailureMessage> failureMessage = getUserFacingOTPSendFailureMessage(e, context);
+            if (failureMessage.isPresent()) {
+                OTPSendFailureMessage message = failureMessage.get();
+                response.addMessage(MessageDTO.MessageType.ERROR, message.getDefaultMessage(),
+                        message.getI18nKey());
+                return;
+            }
             throw handleAuthErrorScenario(e, "Error occurred while sending the OTP in " + getName() + ".");
         }
     }
@@ -546,6 +555,21 @@ public abstract class AbstractOTPExecutor extends AuthenticationExecutor {
         int resendCount = getCurrentResendCount(context) + 1;
         context.setProperty(OTPExecutorConstants.OTP_RESEND_COUNT, resendCount);
         response.getContextProperties().put(OTPExecutorConstants.OTP_RESEND_COUNT, resendCount);
+    }
+
+    /**
+     * Resolves a user-facing message for an OTP sending failure that should be surfaced on the OTP
+     * page instead of failing the flow.
+     *
+     * @param e       The exception raised while sending the OTP.
+     * @param context The current flow execution context.
+     * @return A populated {@link OTPSendFailureMessage} when the failure should be shown on the OTP
+     *         page, or {@link Optional#empty()} to let the failure abort the flow.
+     */
+    protected Optional<OTPSendFailureMessage> getUserFacingOTPSendFailureMessage(Exception e,
+                                                                                FlowExecutionContext context) {
+
+        return Optional.empty();
     }
 
     abstract protected Event getSendOTPEvent(OTPExecutorConstants.OTPScenarios otpScenario, OTP otp,

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/model/OTPSendFailureMessage.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/main/java/org/wso2/carbon/identity/auth/otp/core/model/OTPSendFailureMessage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.otp.core.model;
+
+/**
+ * Immutable value object that carries the i18n key and default message an OTP executor uses to
+ * render an OTP-sending failure on the OTP page instead of aborting the flow.
+ */
+public final class OTPSendFailureMessage {
+
+    private final String i18nKey;
+    private final String defaultMessage;
+
+    public OTPSendFailureMessage(String i18nKey, String defaultMessage) {
+
+        this.i18nKey = i18nKey;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public String getI18nKey() {
+
+        return i18nKey;
+    }
+
+    public String getDefaultMessage() {
+
+        return defaultMessage;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutorTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/AbstractOTPExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.auth.otp.core.constant.OTPExecutorConstants;
 import org.wso2.carbon.identity.auth.otp.core.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.auth.otp.core.model.OTPSendFailureMessage;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -36,14 +37,18 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.mgt.model.MessageDTO;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -54,7 +59,6 @@ import static org.wso2.carbon.identity.event.IdentityEventConstants.EventPropert
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.OTP_STATUS;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.OTP_USED_TIME;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_ERROR;
@@ -416,5 +420,72 @@ public class AbstractOTPExecutorTest {
         Exception e = new Exception("Test Exception");
         FlowEngineException ex = testOTPExecutor.handleAuthErrorScenario(e);
         Assert.assertTrue(ex.getDescription().contains("Error occurred in TestExecutor"));
+    }
+
+    @Test
+    public void testGetUserFacingOTPSendFailureMessageDefaultReturnsEmpty() {
+
+        Optional<OTPSendFailureMessage> result = testOTPExecutor.getUserFacingOTPSendFailureMessage(
+                new IdentityEventException("EP-001", "boom"), flowExecutionContext);
+        Assert.assertFalse(result.isPresent(),
+                "Default implementation must not surface a user-facing message.");
+    }
+
+    @Test
+    public void testTriggerOTPSuppressesFailureWhenUserFacingMessagePresent() throws Exception {
+
+        IdentityEventService partialService = mock(IdentityEventService.class);
+        doNothing().when(partialService).handleEvent(argThat(evt -> evt != null
+                && TestOTPExecutorConstants.TEST_POST_OTP_GENERATION_EVENT.equals(evt.getEventName())));
+        doThrow(new IdentityEventException("EP-100", "Email provider failure"))
+                .when(partialService).handleEvent(argThat(evt -> evt != null
+                        && "TEST_EVENT".equals(evt.getEventName())));
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getIdentityEventService).thenReturn(partialService);
+
+        TestOTPExecutor userFacingExecutor = new TestOTPExecutor() {
+            @Override
+            protected Optional<OTPSendFailureMessage> getUserFacingOTPSendFailureMessage(Exception e,
+                                                                                        FlowExecutionContext context) {
+
+                return Optional.of(new OTPSendFailureMessage("i18n.key", "default-msg"));
+            }
+        };
+
+        userFacingExecutor.triggerOTP(OTPExecutorConstants.OTPScenarios.INITIAL_OTP,
+                flowExecutionContext, response);
+
+        Assert.assertNotNull(response.getMessages(), "Response should contain a user-facing message.");
+        Assert.assertEquals(response.getMessages().size(), 1);
+        MessageDTO added = response.getMessages().get(0);
+        Assert.assertEquals(added.getType(), MessageDTO.MessageType.ERROR);
+        Assert.assertEquals(added.getMessage(), "default-msg");
+        Assert.assertEquals(added.getI18nKey(), "i18n.key");
+        // OTP context data should still be populated even though the send failed.
+        Assert.assertNotNull(response.getContextProperties().get(OTPExecutorConstants.OTP));
+
+        // Restore the shared happy-path stub for subsequent tests.
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getIdentityEventService).thenReturn(identityEventService);
+    }
+
+    @Test(expectedExceptions = FlowEngineException.class)
+    public void testTriggerOTPPropagatesFailureWhenNoUserFacingMessage() throws Exception {
+
+        IdentityEventService partialService = mock(IdentityEventService.class);
+        doNothing().when(partialService).handleEvent(argThat(evt -> evt != null
+                && TestOTPExecutorConstants.TEST_POST_OTP_GENERATION_EVENT.equals(evt.getEventName())));
+        doThrow(new IdentityEventException("EP-100", "Email provider failure"))
+                .when(partialService).handleEvent(argThat(evt -> evt != null
+                        && "TEST_EVENT".equals(evt.getEventName())));
+        dataHolderMockedStatic.when(AuthenticatorDataHolder::getIdentityEventService).thenReturn(partialService);
+
+        try {
+            // Default TestOTPExecutor does not override getUserFacingOTPSendFailureMessage,
+            // so the exception must still abort the flow.
+            testOTPExecutor.triggerOTP(OTPExecutorConstants.OTPScenarios.INITIAL_OTP,
+                    flowExecutionContext, response);
+        } finally {
+            dataHolderMockedStatic.when(AuthenticatorDataHolder::getIdentityEventService)
+                    .thenReturn(identityEventService);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/model/OTPSendFailureMessageTest.java
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/java/org/wso2/carbon/identity/auth/otp/core/model/OTPSendFailureMessageTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.otp.core.model;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link OTPSendFailureMessage}.
+ */
+public class OTPSendFailureMessageTest {
+
+    @Test
+    public void testGettersReturnConstructorValues() {
+
+        OTPSendFailureMessage message = new OTPSendFailureMessage("error.email.notification.EP-1001",
+                "Email provider is unreachable.");
+        Assert.assertEquals(message.getI18nKey(), "error.email.notification.EP-1001");
+        Assert.assertEquals(message.getDefaultMessage(), "Email provider is unreachable.");
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.otp.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.auth.otp.core/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="org.wso2.carbon.identity.auth.otp.core.AbstractOTPAuthenticatorFlowTest"/>
             <class name="org.wso2.carbon.identity.auth.otp.core.ContextBasedOTPControlTest"/>
             <class name="org.wso2.carbon.identity.auth.otp.core.util.AuthenticatorUtilsTest"/>
+            <class name="org.wso2.carbon.identity.auth.otp.core.model.OTPSendFailureMessageTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -89,6 +89,11 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
@@ -263,7 +268,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.10.35</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.152</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)</identity.extension.utils.import.version.range>


### PR DESCRIPTION
## Purpose

Currently, when an OTP executor fails to send an OTP (e.g., the email/SMS provider is unreachable), the exception propagates and aborts the authentication flow. This PR introduces an extension point that lets an executor turn a send failure into a user-facing error message rendered on the OTP page, so the end user sees actionable feedback and can retry without the flow being torn down.

## Changes

- Added `OTPSendFailureMessage` — an immutable value object carrying an i18n key and a default message for a send failure.
- Added `AbstractOTPExecutor#getUserFacingOTPSendFailureMessage(Exception, FlowExecutionContext)` as an extension point. It returns `Optional.empty()` by default (preserving the existing abort-the-flow behavior); subclasses override it to opt in per failure type.
- Updated `triggerOTP(...)` so that when the extension point returns a message for a send failure, the message is attached to the `ExecutorResponse` (as `MessageDTO.MessageType.ERROR`) and the flow continues on the OTP page instead of throwing.
- Added `org.wso2.carbon.identity.flow.mgt` as a dependency (for `MessageDTO`) and bumped `carbon.identity.framework.version` from `7.10.35` to `7.11.152`.
- Added unit tests covering the default (empty) behavior, the suppression path when a user-facing message is provided, the propagation path when it is not, and the `OTPSendFailureMessage` getters.

## Related Issue

- https://github.com/wso2/product-is/issues/28017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OTP failure handling by allowing user-friendly error messages to appear on the OTP page.
  * Added support for localized and default OTP delivery failure messages.

* **Bug Fixes**
  * OTP delivery failures can now be handled gracefully without unnecessarily aborting the authentication flow.

* **Tests**
  * Added coverage for custom failure messages, fallback error handling, and message value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->